### PR TITLE
Enable `publish` job to create GitHub release

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -43,6 +43,7 @@ jobs:
       url: https://pypi.org/p/openbakery
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write  # Required by 'action-gh-release'
 
     steps:
     - name: Get date & flat tag
@@ -69,6 +70,5 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         body: '[Release Notes](https://github.com/miguelsousa/openbakery/blob/main/CHANGELOG.md#${{ steps.date_tag.outputs.VERSION }}---${{ steps.date_tag.outputs.TODAY }})'
-        token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: true
         files: ./dist/*.tar.gz


### PR DESCRIPTION
## Description
- Updated *Build & Publish* workflow to allow `action-gh-release` to create GitHub release

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

