### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -42,9 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Re-enable all platforms
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 from setuptools import setup
 
 try:
-    readme = open("README.md").read()
+    readme = open("README.md", encoding="utf8").read()
 except IOError:
     readme = ""
 

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -420,8 +420,6 @@ def test_check_openbakery_version(mock_get, mock_installed):
     assert "Request to PyPI.org failed with this message" in msg
 
 
-# TODO: Remove skip decorator
-@pytest.mark.skip(reason="not available on PyPI yet")
 def test_check_openbakery_version_live_apis():
     """Check if OpenBakery is up-to-date. (No API-mocking edition)"""
     check = CheckTester(universal_profile, "com.google.fonts/check/openbakery_version")

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1144,6 +1144,11 @@ def test_check_freetype_rasterizer():
     msg = assert_results_contain(check(font), FAIL, "freetype-crash")
     assert "FT_Exception:  (stack overflow)" in msg
 
+    # Example that segfaults with 'freetype-py' version 2.4.0
+    font = TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.ttf")
+    msg = assert_PASS(check(font), "with a good font...")
+    assert msg == "Font can be rasterized by FreeType."
+
 
 def test_check_sfnt_version():
     """Ensure that the font has the proper sfntVersion value."""


### PR DESCRIPTION
## Description
- Re-enabled running the tests on all platforms. This uncovered an error on Windows, when `setup.py` opens `README.md`
- `test_check_openbakery_version_live_apis` is no longer skipped
- Added test example that `segfault`s with `freetype-py` version 2.4.0. This makes sure the problem won't go unnoticed, and will enable us to know when it gets fixed

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

