### PR TITLE
Update AUTHORS.txt

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -5,11 +5,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+      - '**.txt'
 
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+      - '**.txt'
 
 jobs:
   lint:

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,4 @@
-# This is the official list of Font Bakery authors for copyright purposes.
+# This is the official list of Open Bakery authors for copyright purposes.
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 
@@ -6,6 +6,7 @@
 # Name or Organization <email address>
 # The email address is not required for organizations.
 
+Adobe Systems Incorporated
 Google Inc.
 Mikhail Kashkin <mkashkin@gmail.com>
 Brian Dickens <hostilefork@gmail.com>


### PR DESCRIPTION
## Description
(Relates to discussion #1, to go with bringing CONTRIBUTORS up to date)

Adobe should have been added to the AUTHORS file a long time ago in the fontbakery project, since the Google CLA doesn't take copyright assignment, so Adobe is a copyright holder for the contributions made by Adobe employees.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

