### PR TITLE
Create `iso15008` extra

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -8,6 +8,7 @@ on:
       - '**.txt'
 
   pull_request:
+    types: [opened]
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+
+- `iso15008` extra. To run the `check-iso15008` profile it's now necessary to install **openbakery** like so:
+
+        python -m pip install -U 'openbakery[iso15008]'
+
+
 ## [0.1.0] - 2023-06-11
 
 First release. This version is functionally equivalent to Font Bakery version 0.8.13.

--- a/Lib/openbakery/profiles/iso15008.py
+++ b/Lib/openbakery/profiles/iso15008.py
@@ -2,16 +2,29 @@
 Checks for suitability for in-car displays (ISO 15008).
 """
 
+from fontTools.pens.boundsPen import BoundsPen
+
 from openbakery.callable import check
-from openbakery.section import Section
-from openbakery.status import PASS, FAIL
 from openbakery.fonts_profile import profile_factory
 from openbakery.message import Message
-from fontTools.pens.boundsPen import BoundsPen
-from beziers.path import BezierPath
-from beziers.line import Line
-from beziers.point import Point
-import uharfbuzz as hb
+from openbakery.section import Section
+from openbakery.status import PASS, FAIL
+
+
+try:
+    from beziers.path import BezierPath
+    from beziers.line import Line
+    from beziers.point import Point
+    import uharfbuzz as hb
+except ImportError:
+    import sys
+
+    sys.exit(
+        "\nTo run the iso15008 profile, one needs to install\n"
+        "openbakery with the 'iso15008' extra, like this:\n"
+        "\n"
+        "python -m pip install -U 'openbakery[iso15008]'\n\n"
+    )
 
 
 profile = profile_factory(default_section=Section("Suitability for In-Car Display"))

--- a/Lib/openbakery/profiles/iso15008.py
+++ b/Lib/openbakery/profiles/iso15008.py
@@ -2,16 +2,15 @@
 Checks for suitability for in-car displays (ISO 15008).
 """
 
-from openbakery.callable import check, condition
+from openbakery.callable import check
 from openbakery.section import Section
-from openbakery.status import PASS, FAIL, WARN
+from openbakery.status import PASS, FAIL
 from openbakery.fonts_profile import profile_factory
 from openbakery.message import Message
 from fontTools.pens.boundsPen import BoundsPen
 from beziers.path import BezierPath
 from beziers.line import Line
 from beziers.point import Point
-import beziers
 import uharfbuzz as hb
 
 
@@ -89,7 +88,7 @@ def pair_kerning(font, left, right):
     rationale="""
         According to ISO 15008, fonts used for in-car displays should not be
         too narrow or too wide.
-        
+
         To ensure legibility of this font on in-car information systems,
         it is recommended that the ratio of H width to H height
         is between 0.65 and 0.80.
@@ -129,7 +128,7 @@ def com_google_fonts_check_iso15008_proportions(ttFont):
     rationale="""
         According to ISO 15008, fonts used for in-car displays should
         not be too light or too bold.
-        
+
         To ensure legibility of this font on in-car information systems,
         it is recommended that the ratio of stem width to ascender height
         is between 0.10 and 0.20.
@@ -163,16 +162,16 @@ def com_google_fonts_check_iso15008_stem_width(ttFont):
     rationale="""
         According to ISO 15008, fonts used for in-car displays should not
         be too narrow or too wide.
-        
+
         To ensure legibility of this font on in-car information systems,
         it is recommended that the spacing falls within the following values:
-        
+
         * space between vertical strokes (e.g. "ll") should be 150%-240%
           of the stem width.
-        
+
         * space between diagonals and verticals (e.g. "vl") should be
           at least 85% of the stem width.
-        
+
         * diagonal characters should not touch (e.g. "vv").
     """
     + DISCLAIMER,
@@ -256,7 +255,7 @@ def com_google_fonts_check_iso15008_intercharacter_spacing(font, ttFont):
     rationale="""
         According to ISO 15008, fonts used for in-car displays
         should not be too narrow or too wide.
-        
+
         To ensure legibility of this font on in-car information systems,
         it is recommended that the space character should have advance width
         between 250% and 300% of the space between the letters l and m.
@@ -310,7 +309,7 @@ def com_google_fonts_check_iso15008_interword_spacing(font, ttFont):
     rationale="""
         According to ISO 15008, fonts used for in-car displays
         should not be too narrow or too wide.
-        
+
         To ensure legibility of this font on in-car information systems,
         it is recommended that the vertical metrics be set to a minimum
         at least one stem width between the bottom of the descender

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ except IOError:
     readme = ""
 
 
+BEZIERS_VERSION = ">=0.5.0"
 FONTTOOLS_VERSION = ">=4.39.0"  # Python 3.8+ required
 UFO2FT_VERSION = ">=2.25.2"
 
@@ -47,13 +48,24 @@ googlefonts_extras = [
     # (see https://github.com/googlefonts/fontbakery/issues/2200)
 ] + ufo_sources_extras
 
+iso15008_extras = [
+    f"beziers{BEZIERS_VERSION}",
+    "uharfbuzz",
+]
+
 fontval_extras = [
     "lxml",
 ]
 
 docs_extras = []
 
-all_extras = set(docs_extras + googlefonts_extras + fontval_extras + ufo_sources_extras)
+all_extras = set(
+    docs_extras
+    + fontval_extras
+    + googlefonts_extras
+    + iso15008_extras
+    + ufo_sources_extras
+)
 
 setup(
     name="openbakery",
@@ -125,7 +137,7 @@ setup(
         "requests",  # Universal & googlefonts profiles
         #
         # TODO: Try to split the packages below into feature-specific extras.
-        "beziers>=0.5.0",  # Opentype, iso15008, Shaping (& Universal) profiles
+        f"beziers{BEZIERS_VERSION}",  # Opentype, Shaping (& Universal) profiles
         # Uses new fontTools glyph outline access
         "collidoscope>=0.5.2",  # Shaping (& Universal) profiles
         # 0.5.1 did not yet support python 3.11
@@ -139,8 +151,9 @@ setup(
     extras_require={
         "all": all_extras,
         "docs": docs_extras,
-        "googlefonts": googlefonts_extras,
         "fontval": fontval_extras,
+        "googlefonts": googlefonts_extras,
+        "iso15008": iso15008_extras,
         "ufo-sources": ufo_sources_extras,
     },
     entry_points={


### PR DESCRIPTION
## Description
Fixes #20

- Created `iso15008` extra. To run the `check-iso15008` profile it's now necessary to install **openbakery** with this extra, like so:

        python -m pip install -U 'openbakery[iso15008]'

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

