### PR TITLE
Fix ERRORs in `com.google.fonts/check/interpolation_issues` and `com.google.fonts/check/fontvalidator`

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+        cache: 'pip' # caching pip dependencies
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/install_run.yml
+++ b/.github/workflows/install_run.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        cache: 'pip' # caching pip dependencies
 
     - name: Install OpenBakery (no extras)
       run: |

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        cache: 'pip' # caching pip dependencies
 
     - name: Install dependencies
       run: |
@@ -57,6 +58,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
 
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
         python -m pip install -U 'openbakery[iso15008]'
 
+### Changed
+
+- `com.google.fonts/check/fontvalidator`: The check emitted an ERROR if FontValidator isn't installed. It now emits a FAIL (#30).
+
 ### Fixed
 
 - `com.google.fonts/check/interpolation_issues`: The check ERRORed when ran on CFF2 variable fonts. The check is now SKIPped for such fonts because it depends on the presence of the `gvar` table, which only apply to TrueType variable fonts (#28).
+- `com.google.fonts/check/fontvalidator`: ERROR caused by attempting to run FontValidator before checking if it's installed (#30).
 
 ## [0.1.0] - 2023-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
         python -m pip install -U 'openbakery[iso15008]'
 
+### Fixed
+
+- `com.google.fonts/check/interpolation_issues`: The check ERRORed when ran on CFF2 variable fonts. The check is now SKIPped for such fonts because it depends on the presence of the `gvar` table, which only apply to TrueType variable fonts (#28).
 
 ## [0.1.0] - 2023-06-11
 

--- a/Lib/openbakery/profiles/fontval.py
+++ b/Lib/openbakery/profiles/fontval.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+import shutil
 import tempfile
 
 from openbakery.callable import check
 from openbakery.fonts_profile import profile_factory
-from openbakery.status import ERROR, FAIL, INFO, PASS, WARN
+from openbakery.status import FAIL, INFO, PASS, WARN
 from openbakery.section import Section
 from openbakery.message import Message
 from openbakery.utils import exit_with_install_instructions
@@ -33,6 +34,13 @@ def com_google_fonts_check_fontvalidator(font, config):
             "The check config must contain either enabled_checks or "
             "disabled_checks, but not both."
         )
+
+    if not shutil.which("FontValidator"):
+        yield FAIL, Message(
+            "fontval-not-available",
+            "Mono runtime and/or Microsoft Font Validator" " are not available!",
+        )
+        return
 
     # In some cases we want to override the severity level of
     # certain checks in FontValidator:
@@ -177,12 +185,6 @@ def com_google_fonts_check_fontvalidator(font, config):
                 " Output follows :\n\n{}\n"
             ).format("\n".join(filtered_output)),
         )
-    except (OSError, IOError) as error:
-        yield ERROR, Message(
-            "fontval-not-available",
-            "Mono runtime and/or Microsoft Font Validator" " are not available!",
-        )
-        raise error
 
     def report_message(msg, details):
         if details:

--- a/Lib/openbakery/profiles/fontval.py
+++ b/Lib/openbakery/profiles/fontval.py
@@ -12,7 +12,7 @@ from openbakery.utils import exit_with_install_instructions
 from .shared_conditions import is_cff, is_variable_font
 
 try:
-    from lxml import etree
+    import lxml.etree
 except ImportError:
     exit_with_install_instructions("fontval")
 
@@ -213,7 +213,7 @@ def com_google_fonts_check_fontvalidator(font, config):
 
     grouped_msgs = {}
     with open(report_file, "rb") as xml_report:
-        doc = etree.fromstring(xml_report.read())
+        doc = lxml.etree.fromstring(xml_report.read())
         for report in doc.iterfind(".//Report"):
             msg = report.get("Message")
             details = report.get("Details")

--- a/Lib/openbakery/profiles/googlefonts.py
+++ b/Lib/openbakery/profiles/googlefonts.py
@@ -136,10 +136,8 @@ NAME_TABLE_CHECKS = [
 #  we implement check polymorphism
 # https://github.com/googlefonts/fontbakery/issues/3436
 GLYPHSAPP_CHECKS = [
-    # DISABLED:
-    # "com.google.fonts/check/glyphs_file/name/family_and_style_max_length",
-    # DISABLED:
-    # "com.google.fonts/check/glyphs_file/font_copyright",
+    # DISABLED: "com.google.fonts/check/glyphs_file/name/family_and_style_max_length",
+    # DISABLED: "com.google.fonts/check/glyphs_file/font_copyright",
 ]
 
 REPO_CHECKS = [
@@ -162,7 +160,7 @@ FONT_FILE_CHECKS = [
     "com.google.fonts/check/ligature_carets",
     "com.google.fonts/check/production_glyphs_similarity",
     "com.google.fonts/check/fontv",
-    # DISABLED:     'com.google.fonts/check/production_encoded_glyphs',
+    # DISABLED: "com.google.fonts/check/production_encoded_glyphs",
     "com.google.fonts/check/glyf_nested_components",
     "com.google.fonts/check/varfont/generate_static",
     "com.google.fonts/check/kerning_for_non_ligated_sequences",

--- a/Lib/openbakery/profiles/googlefonts.py
+++ b/Lib/openbakery/profiles/googlefonts.py
@@ -251,11 +251,12 @@ def com_google_fonts_check_canonical_filename(ttFont):
     """Checking file is named canonically."""
     try:
         from axisregistry import build_filename
+
+        current_filename = os.path.basename(ttFont.reader.file.name)
+        expected_filename = build_filename(ttFont)
     except ImportError:
         exit_with_install_instructions("googlefonts")
 
-    current_filename = os.path.basename(ttFont.reader.file.name)
-    expected_filename = build_filename(ttFont)
     if current_filename != expected_filename:
         yield FAIL, Message(
             "bad-filename", f'Expected "{expected_filename}. Got {current_filename}.'

--- a/Lib/openbakery/profiles/iso15008.py
+++ b/Lib/openbakery/profiles/iso15008.py
@@ -1,7 +1,9 @@
 """
 Checks for suitability for in-car displays (ISO 15008).
 """
-
+from beziers.line import Line
+from beziers.path import BezierPath
+from beziers.point import Point
 from fontTools.pens.boundsPen import BoundsPen
 
 from openbakery.callable import check
@@ -12,9 +14,6 @@ from openbakery.status import PASS, FAIL
 from openbakery.utils import exit_with_install_instructions
 
 try:
-    from beziers.path import BezierPath
-    from beziers.line import Line
-    from beziers.point import Point
     import uharfbuzz as hb
 except ImportError:
     exit_with_install_instructions("iso15008")

--- a/Lib/openbakery/profiles/universal.py
+++ b/Lib/openbakery/profiles/universal.py
@@ -1777,7 +1777,7 @@ def com_google_fonts_check_whitespace_widths(ttFont):
 
 @check(
     id="com.google.fonts/check/interpolation_issues",
-    conditions=["is_variable_font"],
+    conditions=["is_variable_font", "is_ttf"],
     severity=4,
     rationale="""
         When creating a variable font, the designer must make sure that

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ except IOError:
     readme = ""
 
 
-BEZIERS_VERSION = ">=0.5.0"
 FONTTOOLS_VERSION = ">=4.39.0"  # Python 3.8+ required
-UFO2FT_VERSION = ">=2.25.2"
+UFO2FT_VERSION = ">=2.25.2"  # 2.25.2 updated the script lists for Unicode 14.0
 
 # Profile-specific dependencies:
 ufo_sources_extras = [
@@ -40,7 +39,7 @@ googlefonts_extras = [
     "dehinter>=3.1.0",  # 3.1.0 added dehinter.font.hint function
     "font-v",
     f"fontTools[lxml,unicode]{FONTTOOLS_VERSION}",
-    "gflanguages>=0.3.0",  # There was an api simplification/update on v0.3.0
+    "gflanguages>=0.3.0",  # 0.3.0 had an api simplification/update
     # (see https://github.com/googlefonts/gflanguages/pull/7)
     "glyphsets>=0.5.0",
     "protobuf>=3.7.0, <4",  # 3.7.0 fixed a bug on parsing some METADATA.pb files.
@@ -49,7 +48,6 @@ googlefonts_extras = [
 ] + ufo_sources_extras
 
 iso15008_extras = [
-    f"beziers{BEZIERS_VERSION}",
     "uharfbuzz",
 ]
 
@@ -114,37 +112,42 @@ setup(
         "setuptools_scm[toml]>=6.2",
     ],
     install_requires=[
-        # --- core dependencies
+        # ---
+        # core dependencies
         f"fontTools{FONTTOOLS_VERSION}",
         "freetype-py!=2.4.0",  # Avoiding 2.4.0 due to seg-fault described at
         # https://github.com/googlefonts/fontbakery/issues/4143
-        "munkres",  # For interpolation compatibility checking (fontTools dependency)
         "opentypespec",
         "opentype-sanitizer>=7.1.9",  # 7.1.9 fixes caret value format = 3 bug
         # (see https://github.com/khaledhosny/ots/pull/182)
-        #
-        # --- for parsing Configuration files
+        # ---
+        # fontTools extra that is needed by 'interpolation_issues' check in
+        # Universal profile
+        "munkres",
+        # ---
+        # for parsing Configuration files (Lib/openbakery/configuration.py)
         "PyYAML",
         "toml",
-        #
-        # --- used by Reporters
-        "cmarkgfm",
-        "rich",
-        #
-        # --- for checking OpenBakery's version
-        "packaging",  # Universal profile
-        "pip-api",  # Universal profile
-        "requests",  # Universal & googlefonts profiles
+        # ---
+        # used by Reporters (Lib/openbakery/reporters)
+        "cmarkgfm",  # (html.py)
+        "rich",  # (terminal.py)
+        # ---
+        # used by 'openbakery_version' check in Universal profile
+        "packaging",
+        "pip-api",
+        "requests",  # also used by Google Fonts profile
+        # ---
+        # used by 'italic_angle' check in OpenType profile ('post' table);
+        # also used by ISO 15008 profile
+        "beziers>=0.5.0",  # 0.5.0 uses new fontTools glyph outline access
         #
         # TODO: Try to split the packages below into feature-specific extras.
-        f"beziers{BEZIERS_VERSION}",  # Opentype, Shaping (& Universal) profiles
-        # Uses new fontTools glyph outline access
         "collidoscope>=0.5.2",  # Shaping (& Universal) profiles
         # 0.5.1 did not yet support python 3.11
         # (see https://github.com/googlefonts/fontbakery/issues/3970)
         "stringbrewer",  # Shaping (& Universal) profiles
         f"ufo2ft{UFO2FT_VERSION}",  # Shaping
-        # 2.25.2 updated the script lists for Unicode 14.0
         "vharfbuzz>=0.2.0",  # Googlefonts, Shaping (& Universal) profiles
         # v0.2.0 had an API update
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+
+
+def reload_module(module_name):
+    module = importlib.import_module(module_name)
+    importlib.reload(module)
+
+
+class ImportRaiser:
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self.module_name:
+            raise ImportError()
+
+
+def remove_import_raiser(module_name):
+    for item in sys.meta_path:
+        if hasattr(item, "module_name") and item.module_name == module_name:
+            sys.meta_path.remove(item)

--- a/tests/profiles/fontval_test.py
+++ b/tests/profiles/fontval_test.py
@@ -1,10 +1,24 @@
 import shutil
+import sys
 
 import pytest
+
+from conftest import ImportRaiser, remove_import_raiser, reload_module
 
 from openbakery.codetesting import TEST_FILE, assert_results_contain, CheckTester
 from openbakery.status import FAIL
 from openbakery.profiles import fontval as fontval_profile
+
+
+def test_extra_needed_exit(monkeypatch):
+    module_name = "lxml.etree"
+    sys.meta_path.insert(0, ImportRaiser(module_name))
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    with pytest.raises(SystemExit):
+        reload_module("openbakery.profiles.fontval")
+
+    remove_import_raiser(module_name)
 
 
 def test_check_fontvalidator_not_installed():

--- a/tests/profiles/fontval_test.py
+++ b/tests/profiles/fontval_test.py
@@ -2,9 +2,15 @@ import shutil
 
 import pytest
 
-from openbakery.codetesting import TEST_FILE, assert_results_contain
-from openbakery.status import ERROR
+from openbakery.codetesting import TEST_FILE, assert_results_contain, CheckTester
+from openbakery.status import FAIL
 from openbakery.profiles import fontval as fontval_profile
+
+
+def test_check_fontvalidator_not_installed():
+    check = CheckTester(fontval_profile, "com.google.fonts/check/fontvalidator")
+    font = TEST_FILE("mada/Mada-Regular.ttf")
+    assert_results_contain(check(font), FAIL, "fontval-not-available")
 
 
 @pytest.mark.skipif(
@@ -13,23 +19,4 @@ from openbakery.profiles import fontval as fontval_profile
 )
 def test_check_fontvalidator():
     """MS Font Validator checks"""
-    # check = CheckTester(fontval_profile,
-    #                     "com.google.fonts/check/fontvalidator")
-    check = fontval_profile.com_google_fonts_check_fontvalidator
-
-    font = TEST_FILE("mada/Mada-Regular.ttf")
-    config = {}
-
-    # Then we make sure that there wasn't an ERROR
-    # which would mean FontValidator is not properly installed:
-    for status, message in check(font, config):
-        assert status != ERROR
-
-    # Simulate FontVal missing.
-    import os
-
-    old_path = os.environ["PATH"]
-    os.environ["PATH"] = ""
-    with pytest.raises(OSError) as _:
-        assert_results_contain(check(font, config), ERROR, "fontval-not-available")
-    os.environ["PATH"] = old_path
+    raise NotImplementedError

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -177,20 +177,16 @@ def test_example_checkrunner_based(cabin_regular_path):
         (TEST_FILE("montserrat/Montserrat-ExtraBoldItalic.ttf"), PASS),
         (TEST_FILE("montserrat/Montserrat-BlackItalic.ttf"), PASS),
         (TEST_FILE("cabinvfbeta/CabinVFBeta-Italic[wght].ttf"), PASS),
-        (
-            TEST_FILE("cabinvfbeta/CabinVFBeta[wdth,wght].ttf"),
-            PASS,
-        ),  # axis tags are sorted
         (TEST_FILE("cabinvfbeta/CabinVFBeta.ttf"), FAIL),
         (TEST_FILE("cabinvfbeta/Cabin-Italic.ttf"), FAIL),
         (TEST_FILE("cabinvfbeta/Cabin-Roman.ttf"), FAIL),
         (TEST_FILE("cabinvfbeta/Cabin-Italic-VF.ttf"), FAIL),
         (TEST_FILE("cabinvfbeta/Cabin-Roman-VF.ttf"), FAIL),
         (TEST_FILE("cabinvfbeta/Cabin-VF.ttf"), FAIL),
-        (
-            TEST_FILE("cabinvfbeta/CabinVFBeta[wght,wdth].ttf"),
-            FAIL,
-        ),  # axis tags are NOT sorted here
+        # axis tags are sorted
+        (TEST_FILE("cabinvfbeta/CabinVFBeta[wdth,wght].ttf"), PASS),
+        # axis tags are NOT sorted
+        (TEST_FILE("cabinvfbeta/CabinVFBeta[wght,wdth].ttf"), FAIL),
     ],
 )
 def test_check_canonical_filename(fp, result):

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1,9 +1,13 @@
 import math
 import os
 import shutil
+import sys
+from unittest.mock import patch
 
 import pytest
 from fontTools.ttLib import TTFont
+
+from conftest import ImportRaiser, remove_import_raiser
 
 from openbakery.profiles.googlefonts import can_shape
 from openbakery.profiles.googlefonts_conditions import expected_font_names
@@ -153,6 +157,32 @@ def test_example_checkrunner_based(cabin_regular_path):
         if status == ENDCHECK:
             assert message == WARN and last_check_message.code == "unknown"
             break
+
+
+def test_extra_needed_exit_from_conditions(monkeypatch):
+    module_name = "google.protobuf"
+    sys.meta_path.insert(0, ImportRaiser(module_name))
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    with pytest.raises(SystemExit):
+        check = CheckTester(
+            googlefonts_profile, "com.google.fonts/check/metadata/unknown_designer"
+        )
+        font = TEST_FILE("merriweather/Merriweather.ttf")
+        check(font)
+
+    remove_import_raiser(module_name)
+
+
+@patch("axisregistry.build_filename", side_effect=ImportError)
+def test_extra_needed_exit(mock_import_error):
+    ttFont = TTFont(TEST_FILE("cabinvfbeta/Cabin-VF.ttf"))
+    with patch("sys.exit") as mock_exit:
+        check = CheckTester(
+            googlefonts_profile, "com.google.fonts/check/canonical_filename"
+        )
+        check(ttFont)
+        mock_exit.assert_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/profiles/iso15008_test.py
+++ b/tests/profiles/iso15008_test.py
@@ -1,3 +1,9 @@
+import sys
+
+import pytest
+
+from conftest import ImportRaiser, remove_import_raiser, reload_module
+
 from openbakery.status import FAIL
 from openbakery.codetesting import (
     assert_PASS,
@@ -6,6 +12,17 @@ from openbakery.codetesting import (
     TEST_FILE,
 )
 from openbakery.profiles import iso15008 as iso15008_profile
+
+
+def test_extra_needed_exit(monkeypatch):
+    module_name = "uharfbuzz"
+    sys.meta_path.insert(0, ImportRaiser(module_name))
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    with pytest.raises(SystemExit):
+        reload_module("openbakery.profiles.iso15008")
+
+    remove_import_raiser(module_name)
 
 
 def test_check_iso15008_proportions():

--- a/tests/profiles/ufo_sources_test.py
+++ b/tests/profiles/ufo_sources_test.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import defcon
 import pytest
@@ -20,6 +21,17 @@ def empty_ufo_font(tmpdir):
     ufo_path = str(tmpdir.join("empty_font.ufo"))
     ufo.save(ufo_path)
     return (ufo, ufo_path)
+
+
+@patch("defcon.Font", side_effect=ImportError)
+def test_extra_needed_exit(mock_import_error):
+    ufo_path = TEST_FILE("test.ufo")
+    with patch("sys.exit") as mock_exit:
+        check = CheckTester(
+            ufo_sources_profile, "com.daltonmaag/check/ufo_required_fields"
+        )
+        check(ufo_path)
+        mock_exit.assert_called()
 
 
 def test_check_ufolint(empty_ufo_font):

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1212,6 +1212,14 @@ def test_check_interpolation_issues():
     ttFont = TTFont(TEST_FILE("notosansbamum/NotoSansBamum[wght].ttf"))
     assert_results_contain(check(ttFont), WARN, "interpolation-issues")
 
+    ttFont = TTFont(TEST_FILE("mada/Mada-Regular.ttf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: is_variable_font"
+
+    ttFont = TTFont(TEST_FILE("source-sans-pro/VAR/SourceSansVariable-Italic.otf"))
+    msg = assert_results_contain(check(ttFont), SKIP, "unfulfilled-conditions")
+    assert msg == "Unfulfilled Conditions: is_ttf"
+
 
 def test_check_math_signs_width():
     """Check font math signs have the same width."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,25 @@
+from unittest.mock import patch
+
 import pytest
 
 from openbakery.utils import (
     bullet_list,
+    exit_with_install_instructions,
     pretty_print_list,
     text_flow,
     unindent_and_unwrap_rationale,
 )
+
+
+def test_exit_with_install_instructions():
+    extras_name = "test-profile"
+    with patch("sys.exit") as mock_exit:
+        exit_with_install_instructions(extras_name)
+        mock_exit.assert_called_with(
+            f"\nTo run the {extras_name} profile, one needs to install\n"
+            f"openbakery with the '{extras_name}' extra, like this:\n\n"
+            f"    python -m pip install -U 'openbakery[{extras_name}]'\n\n"
+        )
 
 
 def test_text_flow():


### PR DESCRIPTION
## Description
Fixes #28
Fixed #30

- Fixed ERROR in `com.google.fonts/check/interpolation_issues`.
- Fixed an ERROR in `com.google.fonts/check/fontvalidator`.
- Changed another ERROR in `com.google.fonts/check/fontvalidator` to FAIL.
- Made some housekeeping changes to `setup.py`.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

