### PR TITLE
Update list of `extras_require`

### DIFF
--- a/.github/workflows/install_run.yml
+++ b/.github/workflows/install_run.yml
@@ -67,6 +67,21 @@ jobs:
         --verbose
         -c required_tables
 
+    - name: Run Font Bureau checks
+      run: >-
+        openbakery fontbureau
+        -c ots
+        -c ytlc_sanity
+        data/test/fontbureau/ytlcSample.ttf
+
+    - name: Run Adobe Fonts checks
+      run: >-
+        openbakery adobefonts
+        data/test/source-sans-pro/OTF/SourceSansPro-Regular.otf
+        data/test/source-sans-pro/OTF/SourceSansPro-Italic.otf;
+        openbakery adobefonts
+        data/test/source-sans-pro/VAR/SourceSansVariable-Roman.ttf
+
     - name: Try running UFO Sources checks
       run: >-
         openbakery ufo-sources --verbose data/test/test.ufo
@@ -107,6 +122,37 @@ jobs:
         -c contour_count
         -c outline_colinear_vectors
         data/test/cabin/Cabin-*.ttf
+
+    - name: Install `fontwerk` extra
+      run: |
+        python -m pip install '.[fontwerk]'
+
+    - name: Run Fontwerk checks
+      run: >-
+        openbakery fontwerk
+        -c weight_class_fvar
+        -c inconsistencies_between_fvar_stat
+        -c style_linking
+        -c consistent_axes
+        -c metadata/parses
+        -c usweightclass
+        data/test/source-sans-pro/VAR/SourceSansVariable-Roman.ttf
+
+    - name: Install `notofonts` extra
+      run: |
+        python -m pip install '.[notofonts]'
+
+    - name: Run Noto Fonts checks
+      run: >-
+        openbakery notofonts
+        -c unicode_range_bits
+        -c noto_trademark
+        -c noto_vendor
+        -c alien_codepoints
+        -c tnum_horizontal_metrics
+        -c control_chars
+        -c canonical_filename
+        data/test/notosanskhudawadi/NotoSansKhudawadi-Regular.ttf
 
     - name: Uninstall OpenBakery
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         python -m pip install -U 'openbakery[iso15008]'
 
 - `shaping` subcommand and extra (#36).
+- `fontwerk` extra (#37).
+- `notofonts` extra (#37).
 
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,9 @@ setup(
     extras_require={
         "all": all_extras,
         "fontval": fontval_extras,
+        "fontwerk": googlefonts_extras,
         "googlefonts": googlefonts_extras,
+        "notofonts": googlefonts_extras,
         "iso15008": iso15008_extras,
         "shaping": shaping_extras,
         "ufo-sources": ufo_sources_extras,

--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,8 @@ fontval_extras = [
     "lxml",
 ]
 
-docs_extras = []
-
 all_extras = set(
-    docs_extras
-    + fontval_extras
+    fontval_extras
     + googlefonts_extras
     + iso15008_extras
     + shaping_extras
@@ -160,7 +157,6 @@ setup(
     ],
     extras_require={
         "all": all_extras,
-        "docs": docs_extras,
         "fontval": fontval_extras,
         "googlefonts": googlefonts_extras,
         "iso15008": iso15008_extras,


### PR DESCRIPTION
## Description

- Removed `docs` extra. It was empty since the documentation pages are built with Jekyll, which uses Ruby, not Python.
- Added `fontwerk` and `notofonts` extras.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [ ] request a review

