### PR TITLE
Re-work postscript names checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `com.google.fonts/check/valid_glyphnames`: The check now takes into account that OpenType-CFF2 fonts with `post` table format 3 contain no glyph names, and will yield SKIP (#38).
 - `com.google.fonts/check/unique_glyphnames`: The check now takes into account that OpenType-CFF2 fonts with `post` table format 3 contain no glyph names, and will yield SKIP (#38).
 - `com.google.fonts/check/STAT_in_statics`: The check now skips fonts that do not have a `STAT` table (#38).
+- `com.google.fonts/check/family_naming_recommendations`: Two validations of PostScript name were moved out of this check and into `com.adobe.fonts/check/postscript_name` which yields FAIL (#62).
 
 ### Fixed
 

--- a/Lib/openbakery/profiles/adobefonts.py
+++ b/Lib/openbakery/profiles/adobefonts.py
@@ -26,7 +26,7 @@ profile = profile_factory(default_section=Section("Adobe Fonts"))
 SET_EXPLICIT_CHECKS = {
     # This is the set of explict checks that will be invoked
     # when openbakery is run with the 'adobefonts' subcommand.
-    # The contents of this set were last updated on April 19, 2023.
+    # The contents of this set were last updated on September 6, 2023.
     #
     # =======================================
     # From adobefonts.py (this file)
@@ -132,6 +132,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/family/max_4_fonts_per_family_name",
     "com.adobe.fonts/check/family/consistent_family_name",
     "com.adobe.fonts/check/name/empty_records",
+    "com.adobe.fonts/check/postscript_name",
     "com.adobe.fonts/check/name/postscript_name_consistency",
     "com.adobe.fonts/check/name/postscript_vs_cff",
     "com.google.fonts/check/family_naming_recommendations",

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -438,7 +438,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
                 {
                     "field": "PostScript Name",
                     "value": string,
-                    "rec": ("May contain only a-zA-Z0-9" " characters and a hyphen."),
+                    "rec": ("May contain only a-zA-Z0-9 characters and a hyphen."),
                 }
             )
         if string.count("-") > 1:
@@ -446,7 +446,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
                 {
                     "field": "Postscript Name",
                     "value": string,
-                    "rec": ("May contain not more" " than a single hyphen"),
+                    "rec": ("May contain not more than a single hyphen"),
                 }
             )
 
@@ -457,7 +457,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
             table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
         yield FAIL, Message(
             "bad-psname-entries",
-            "PostScript name does not follow " "requirements:\n" "\n" f"{table}",
+            "PostScript name does not follow requirements:\n\n" f"{table}",
         )
     else:
         yield PASS, Message("psname-ok", "PostScript name follows Adobe requirements.")

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -420,7 +420,8 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
 @check(
     id="com.adobe.fonts/check/postscript_name",
-    proposal="https://github.com/miguelsousa/openbakery/issues/62")
+    proposal="https://github.com/miguelsousa/openbakery/issues/62",
+)
 def com_adobe_fonts_check_postscript_name(ttFont):
     """PostScript name follows Adobe requirements?"""
     import re
@@ -437,8 +438,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
                 {
                     "field": "PostScript Name",
                     "value": string,
-                    "rec": ("May contain only a-zA-Z0-9"
-                            " characters and a hyphen."),
+                    "rec": ("May contain only a-zA-Z0-9" " characters and a hyphen."),
                 }
             )
         if string.count("-") > 1:
@@ -457,10 +457,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
             table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
         yield FAIL, Message(
             "bad-psname-entries",
-            "PostScript name does not follow "
-            "requirements:\n"
-            "\n"
-            f"{table}"
+            "PostScript name does not follow " "requirements:\n" "\n" f"{table}",
         )
     else:
         yield PASS, Message("psname-ok", "PostScript name follows Adobe requirements.")

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -419,12 +419,10 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
 
 @check(
-    id="com.google.fonts/check/family_naming_recommendations",
-    proposal="legacy:check/071",
-)
-def com_google_fonts_check_family_naming_recommendations(ttFont):
-    """Font follows the family naming recommendations?"""
-    # See http://forum.fontlab.com/index.php?topic=313.0
+    id="com.adobe.fonts/check/postscript_name",
+    proposal="https://github.com/miguelsousa/openbakery/issues/62")
+def com_adobe_fonts_check_postscript_name(ttFont):
+    """PostScript name follows Adobe requirements?"""
     import re
     from openbakery.utils import get_name_entry_strings
 
@@ -439,7 +437,8 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
                 {
                     "field": "PostScript Name",
                     "value": string,
-                    "rec": ("May contain only a-zA-Z0-9" " characters and an hyphen."),
+                    "rec": ("May contain only a-zA-Z0-9"
+                            " characters and a hyphen."),
                 }
             )
         if string.count("-") > 1:
@@ -450,6 +449,34 @@ def com_google_fonts_check_family_naming_recommendations(ttFont):
                     "rec": ("May contain not more" " than a single hyphen"),
                 }
             )
+
+    if len(bad_entries) > 0:
+        table = "| Field | Value | Recommendation |\n"
+        table += "|:----- |:----- |:-------------- |\n"
+        for bad in bad_entries:
+            table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
+        yield FAIL, Message(
+            "bad-psname-entries",
+            "PostScript name does not follow "
+            "requirements:\n"
+            "\n"
+            f"{table}"
+        )
+    else:
+        yield PASS, Message("psname-ok", "PostScript name follows Adobe requirements.")
+
+
+@check(
+    id="com.google.fonts/check/family_naming_recommendations",
+    proposal="legacy:check/071",
+)
+def com_google_fonts_check_family_naming_recommendations(ttFont):
+    """Font follows the family naming recommendations?"""
+    # See http://forum.fontlab.com/index.php?topic=313.0
+
+    from openbakery.utils import get_name_entry_strings
+
+    bad_entries = []
 
     for string in get_name_entry_strings(ttFont, NameID.FULL_FONT_NAME):
         if len(string) >= 64:

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -423,7 +423,7 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
     proposal="https://github.com/miguelsousa/openbakery/issues/62",
 )
 def com_adobe_fonts_check_postscript_name(ttFont):
-    """PostScript name follows Adobe requirements?"""
+    """PostScript name follows OpenType specification requirements?"""
     import re
     from openbakery.utils import get_name_entry_strings
 
@@ -446,7 +446,7 @@ def com_adobe_fonts_check_postscript_name(ttFont):
                 {
                     "field": "Postscript Name",
                     "value": string,
-                    "rec": ("May contain not more than a single hyphen"),
+                    "rec": ("May contain not more than a single hyphen."),
                 }
             )
 
@@ -457,10 +457,10 @@ def com_adobe_fonts_check_postscript_name(ttFont):
             table += "| {} | {} | {} |\n".format(bad["field"], bad["value"], bad["rec"])
         yield FAIL, Message(
             "bad-psname-entries",
-            "PostScript name does not follow requirements:\n\n" f"{table}",
+            f"PostScript name does not follow requirements:\n\n{table}",
         )
     else:
-        yield PASS, Message("psname-ok", "PostScript name follows Adobe requirements.")
+        yield PASS, Message("psname-ok", "PostScript name follows requirements.")
 
 
 @check(

--- a/Lib/openbakery/profiles/opentype.py
+++ b/Lib/openbakery/profiles/opentype.py
@@ -70,6 +70,7 @@ OPENTYPE_PROFILE_CHECKS = [
     "com.google.fonts/check/glyf_unused_data",
     "com.google.fonts/check/family_naming_recommendations",
     "com.google.fonts/check/maxadvancewidth",
+    "com.adobe.fonts/check/postscript_name",
     "com.google.fonts/check/points_out_of_bounds",
     "com.google.fonts/check/glyf_non_transformed_duplicate_components",
     "com.google.fonts/check/code_pages",

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -61,7 +61,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 80
+    assert len(SET_EXPLICIT_CHECKS) == 81
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -649,22 +649,20 @@ def test_check_italic_names():
 
 
 def test_check_name_postscript():
-    check = CheckTester(
-        opentype_profile, "com.adobe.fonts/check/postscript_name"
-    )
+    check = CheckTester(opentype_profile, "com.adobe.fonts/check/postscript_name")
 
     # Test a font that has OK psname. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
     assert_PASS(check(ttFont), "psname-ok")
 
     # Change the name-table string. Check should FAIL.
-    bad_ps_name = "this-is-a (bad) name".encode('utf-16-be')
+    bad_ps_name = "this-is-a (bad) name".encode("utf-16-be")
     ttFont["name"].setName(
         bad_ps_name,
         NameID.POSTSCRIPT_NAME,
         PlatformID.WINDOWS,
         WindowsEncodingID.UNICODE_BMP,
-        WindowsLanguageID.ENGLISH_USA
+        WindowsLanguageID.ENGLISH_USA,
     )
     msg = assert_results_contain(check(ttFont), FAIL, "bad-psname-entries")
     assert "PostScript name does not follow requirements" in msg

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -655,8 +655,8 @@ def test_check_name_postscript():
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
     assert_PASS(check(ttFont), "psname-ok")
 
-    # Change the name-table string. Check should FAIL.
-    bad_ps_name = "this-is-a (bad) name".encode("utf-16-be")
+    # Change the PostScript name string to more than one hyphen. Should FAIL.
+    bad_ps_name = "more-than-one-hyphen".encode("utf-16-be")
     ttFont["name"].setName(
         bad_ps_name,
         NameID.POSTSCRIPT_NAME,
@@ -666,5 +666,17 @@ def test_check_name_postscript():
     )
     msg = assert_results_contain(check(ttFont), FAIL, "bad-psname-entries")
     assert "PostScript name does not follow requirements" in msg
-    assert "May contain only a-zA-Z0-9 characters and a hyphen" in msg
-    assert "May contain not more than a single hyphen" in msg
+    assert "May contain not more than a single hyphen." in msg
+
+    # Now change it to a string with illegal characters. Should FAIL.
+    bad_ps_name = "(illegal) characters".encode("utf-16-be")
+    ttFont["name"].setName(
+        bad_ps_name,
+        NameID.POSTSCRIPT_NAME,
+        PlatformID.WINDOWS,
+        WindowsEncodingID.UNICODE_BMP,
+        WindowsLanguageID.ENGLISH_USA,
+    )
+    msg = assert_results_contain(check(ttFont), FAIL, "bad-psname-entries")
+    assert "PostScript name does not follow requirements" in msg
+    assert "May contain only a-zA-Z0-9 characters and a hyphen." in msg

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -356,17 +356,9 @@ def test_check_family_naming_recommendations():
         if name.nameID == NameID.POSTSCRIPT_NAME:
             print("== NameID.POST_SCRIPT_NAME ==")
 
-            print("Test INFO: May contain only a-zA-Z0-9 characters and an hyphen...")
-            # The '@' and '!' chars here are the expected rule violations:
-            name_test("B@zinga!", INFO, "bad-entries")
-
             print("Test PASS: A name with a single hyphen is OK...")
             # A single hypen in the name is OK:
             name_test("Big-Bang", PASS)
-
-            print("Test INFO: May not contain more than a single hyphen...")
-            # The second hyphen char here is the expected rule violation:
-            name_test("Big-Bang-Theory", INFO, "bad-entries")
 
             print("Test INFO: Exceeds max length (63)...")
             name_test("A" * 64, INFO, "bad-entries")
@@ -654,3 +646,27 @@ def test_check_italic_names():
     ttFont = TTFont(TEST_FILE("shantell/ShantellSans-Italic[BNCE,INFM,SPAC,wght].ttf"))
     set_name(ttFont, 17, "Light")
     assert_results_contain(check(ttFont), FAIL, "bad-typographicsubfamilyname")
+
+
+def test_check_name_postscript():
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/postscript_name"
+    )
+
+    # Test a font that has OK psname. Check should PASS.
+    ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
+    assert_PASS(check(ttFont), "psname-ok")
+
+    # Change the name-table string. Check should FAIL.
+    bad_ps_name = "this-is-a (bad) name".encode('utf-16-be')
+    ttFont["name"].setName(
+        bad_ps_name,
+        NameID.POSTSCRIPT_NAME,
+        PlatformID.WINDOWS,
+        WindowsEncodingID.UNICODE_BMP,
+        WindowsLanguageID.ENGLISH_USA
+    )
+    msg = assert_results_contain(check(ttFont), FAIL, "bad-psname-entries")
+    assert "PostScript name does not follow requirements" in msg
+    assert "May contain only a-zA-Z0-9 characters and a hyphen" in msg
+    assert "May contain not more than a single hyphen" in msg


### PR DESCRIPTION
## Description
Addresses #62

Moves critical checks of postscript name (multiple hyphens, illegal characters) out of general names check and into their own check, with FAIL result on bad names instead of INFO.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

