### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -85,6 +85,6 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Reverts miguelsousa/openbakery#68

The v4 release is now showing as `v4.0.0-beta.x` which is [breaking the CI](https://github.com/miguelsousa/openbakery/actions/runs/6214739722/job/16866973769?pr=69)