### PR TITLE
Improve `codetesting` methods

### DIFF
--- a/Lib/openbakery/codetesting.py
+++ b/Lib/openbakery/codetesting.py
@@ -209,6 +209,11 @@ def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
         return None
     else:
         assert status == PASS
+        # If the yielded result if of type Message, validate its code string.
+        if isinstance(message, Message):
+            assert (
+                message.code == reason
+            ), f"Expected {reason!r} but got {message.code!r}"
         return str(message)
 
 

--- a/Lib/openbakery/codetesting.py
+++ b/Lib/openbakery/codetesting.py
@@ -201,12 +201,13 @@ def GLYPHSAPP_TEST_FILE(f):
     return glyphsLib.load(open(the_file, encoding="utf-8"))
 
 
-def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
-    status, message = list(check_results)[-1]
-    if ignore_error and status == ERROR:
+def _assert_last_status(status, check_results, reason, ignore_error=None):
+    """Validates the status of the last check result, as well as its code string"""
+    last_status, message = list(check_results)[-1]
+    if ignore_error and last_status == ERROR:
         return None
     else:
-        assert status == PASS
+        assert last_status == status
         # If the yielded result if of type Message, validate its code string.
         if isinstance(message, Message):
             assert (
@@ -215,10 +216,14 @@ def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
         return str(message)
 
 
+def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
+    """Validates that the last check result is a PASS"""
+    return _assert_last_status(PASS, check_results, reason, ignore_error)
+
+
 def assert_SKIP(check_results, reason=""):
-    status, message = list(check_results)[-1]
-    assert status == SKIP
-    return str(message)
+    """Validates that the last check result is a SKIP"""
+    return _assert_last_status(SKIP, check_results, reason)
 
 
 def assert_results_contain(

--- a/Lib/openbakery/codetesting.py
+++ b/Lib/openbakery/codetesting.py
@@ -202,10 +202,8 @@ def GLYPHSAPP_TEST_FILE(f):
 
 
 def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
-    print(f"Test PASS {reason}")
     status, message = list(check_results)[-1]
     if ignore_error and status == ERROR:
-        print(ignore_error)
         return None
     else:
         assert status == PASS
@@ -218,7 +216,6 @@ def assert_PASS(check_results, reason="with a good font...", ignore_error=None):
 
 
 def assert_SKIP(check_results, reason=""):
-    print(f"Test SKIP {reason}")
     status, message = list(check_results)[-1]
     assert status == SKIP
     return str(message)

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -655,7 +655,7 @@ def test_check_name_postscript_characters():
 
     # Test a font that has psname with allowed characters. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
-    assert_PASS(check(ttFont), "psname-ok")
+    assert_PASS(check(ttFont), "psname-characters-ok")
 
     # Change it to a string with disallowed characters. Should FAIL.
     bad_ps_name = "(disallowed) characters".encode("utf-16-be")
@@ -677,7 +677,7 @@ def test_check_name_postscript_hyphens():
 
     # Test a font that has OK psname. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
-    assert_PASS(check(ttFont), "psname-ok")
+    assert_PASS(check(ttFont), "psname-hyphens-ok")
 
     # Change the PostScript name string to more than one hyphen. Should FAIL.
     bad_ps_name = "more-than-one-hyphen".encode("utf-16-be")

--- a/tests/profiles/name_test.py
+++ b/tests/profiles/name_test.py
@@ -655,7 +655,7 @@ def test_check_name_postscript_characters():
 
     # Test a font that has psname with allowed characters. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
-    assert_results_contain(check(ttFont), PASS, "psname-characters-ok")
+    assert_PASS(check(ttFont), "psname-ok")
 
     # Change it to a string with disallowed characters. Should FAIL.
     bad_ps_name = "(disallowed) characters".encode("utf-16-be")
@@ -677,7 +677,7 @@ def test_check_name_postscript_hyphens():
 
     # Test a font that has OK psname. Check should PASS.
     ttFont = TTFont(TEST_FILE("source-sans-pro/OTF/SourceSansPro-Bold.otf"))
-    assert_results_contain(check(ttFont), PASS, "psname-hyphens-ok")
+    assert_PASS(check(ttFont), "psname-ok")
 
     # Change the PostScript name string to more than one hyphen. Should FAIL.
     bad_ps_name = "more-than-one-hyphen".encode("utf-16-be")

--- a/tests/test_codetesting.py
+++ b/tests/test_codetesting.py
@@ -32,6 +32,10 @@ def test_GLYPHSAPP_TEST_FILE():
     assert isinstance(gfile, GSFont)
 
 
+# ========================================================================
+# assert_SKIP tests
+
+
 def test_assert_SKIP_success(capsys):
     skip_msg = "SKIP message"
     skip_reason = "SKIP reason"
@@ -59,14 +63,77 @@ def test_assert_SKIP_failure(capsys):
     assert captured.out == f"Test SKIP {skip_reason}\n"
 
 
-def test_assert_PASS_success(capsys):
+# ========================================================================
+# assert_PASS tests
+
+
+def test_assert_PASS_success_no_reason(capsys):
     pass_msg = "PASS message"
-    pass_reason = "with a good font..."
+    dflt_reason = "with a good font..."
     results = [
         (SKIP,),
         (PASS, pass_msg),
     ]
     assert assert_PASS(results) == pass_msg
+
+    captured = capsys.readouterr()
+    assert captured.out == f"Test PASS {dflt_reason}\n"
+
+
+def test_assert_PASS_success_custom_reason(capsys):
+    pass_msg = "PASS message"
+    pass_reason = "custom reason"
+    results = [
+        (SKIP,),
+        (PASS, pass_msg),
+    ]
+    assert assert_PASS(results, pass_reason) == pass_msg
+
+    captured = capsys.readouterr()
+    assert captured.out == f"Test PASS {pass_reason}\n"
+
+
+def test_assert_PASS_failure_no_reason_message_yield(capsys):
+    msg_code = "message-code"
+    pass_msg = Message(msg_code, "custom message")
+    dflt_reason = "with a good font..."
+    results = [
+        (SKIP,),
+        (PASS, pass_msg),
+    ]
+    with pytest.raises(AssertionError) as err:
+        assert_PASS(results)
+    assert str(err.value) == f"Expected {dflt_reason!r} but got {msg_code!r}"
+
+    captured = capsys.readouterr()
+    assert captured.out == f"Test PASS {dflt_reason}\n"
+
+
+def test_assert_PASS_success_message_yield(capsys):
+    msg_code = "message-code"
+    pass_msg = Message(msg_code, "custom message")
+    pass_reason = msg_code
+    results = [
+        (SKIP,),
+        (PASS, pass_msg),
+    ]
+    assert assert_PASS(results, pass_reason) == str(pass_msg)
+
+    captured = capsys.readouterr()
+    assert captured.out == f"Test PASS {pass_reason}\n"
+
+
+def test_assert_PASS_failure_message_yield(capsys):
+    msg_code = "message-code"
+    pass_msg = Message(msg_code, "custom message")
+    pass_reason = f"different-{msg_code}"
+    results = [
+        (SKIP,),
+        (PASS, pass_msg),
+    ]
+    with pytest.raises(AssertionError) as err:
+        assert_PASS(results, pass_reason)
+    assert str(err.value) == f"Expected {pass_reason!r} but got {msg_code!r}"
 
     captured = capsys.readouterr()
     assert captured.out == f"Test PASS {pass_reason}\n"
@@ -112,6 +179,10 @@ def test_assert_PASS_ignore_error_false(capsys):
 
     captured = capsys.readouterr()
     assert captured.out == f"Test PASS {pass_reason}\n"
+
+
+# ========================================================================
+# assert_results_contain tests
 
 
 def test_assert_results_contain_expected_msgcode_string():

--- a/tests/test_codetesting.py
+++ b/tests/test_codetesting.py
@@ -36,7 +36,7 @@ def test_GLYPHSAPP_TEST_FILE():
 # assert_SKIP tests
 
 
-def test_assert_SKIP_success(capsys):
+def test_assert_SKIP_success():
     skip_msg = "SKIP message"
     skip_reason = "SKIP reason"
     results = [
@@ -45,11 +45,8 @@ def test_assert_SKIP_success(capsys):
     ]
     assert assert_SKIP(results, skip_reason) == skip_msg
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test SKIP {skip_reason}\n"
 
-
-def test_assert_SKIP_failure(capsys):
+def test_assert_SKIP_failure():
     pass_msg = "PASS message"
     skip_reason = "SKIP reason"
     results = [
@@ -59,28 +56,21 @@ def test_assert_SKIP_failure(capsys):
     with pytest.raises(AssertionError):
         assert_SKIP(results, skip_reason)
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test SKIP {skip_reason}\n"
-
 
 # ========================================================================
 # assert_PASS tests
 
 
-def test_assert_PASS_success_no_reason(capsys):
+def test_assert_PASS_success_no_reason():
     pass_msg = "PASS message"
-    dflt_reason = "with a good font..."
     results = [
         (SKIP,),
         (PASS, pass_msg),
     ]
     assert assert_PASS(results) == pass_msg
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {dflt_reason}\n"
 
-
-def test_assert_PASS_success_custom_reason(capsys):
+def test_assert_PASS_success_custom_reason():
     pass_msg = "PASS message"
     pass_reason = "custom reason"
     results = [
@@ -89,11 +79,8 @@ def test_assert_PASS_success_custom_reason(capsys):
     ]
     assert assert_PASS(results, pass_reason) == pass_msg
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n"
 
-
-def test_assert_PASS_failure_no_reason_message_yield(capsys):
+def test_assert_PASS_failure_no_reason_message_yield():
     msg_code = "message-code"
     pass_msg = Message(msg_code, "custom message")
     dflt_reason = "with a good font..."
@@ -105,11 +92,8 @@ def test_assert_PASS_failure_no_reason_message_yield(capsys):
         assert_PASS(results)
     assert str(err.value) == f"Expected {dflt_reason!r} but got {msg_code!r}"
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {dflt_reason}\n"
 
-
-def test_assert_PASS_success_message_yield(capsys):
+def test_assert_PASS_success_message_yield():
     msg_code = "message-code"
     pass_msg = Message(msg_code, "custom message")
     pass_reason = msg_code
@@ -119,11 +103,8 @@ def test_assert_PASS_success_message_yield(capsys):
     ]
     assert assert_PASS(results, pass_reason) == str(pass_msg)
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n"
 
-
-def test_assert_PASS_failure_message_yield(capsys):
+def test_assert_PASS_failure_message_yield():
     msg_code = "message-code"
     pass_msg = Message(msg_code, "custom message")
     pass_reason = f"different-{msg_code}"
@@ -135,13 +116,9 @@ def test_assert_PASS_failure_message_yield(capsys):
         assert_PASS(results, pass_reason)
     assert str(err.value) == f"Expected {pass_reason!r} but got {msg_code!r}"
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n"
 
-
-def test_assert_PASS_failure(capsys):
+def test_assert_PASS_failure():
     skip_msg = "SKIP message"
-    pass_reason = "with a good font..."
     results = [
         (PASS,),
         (SKIP, skip_msg),
@@ -149,13 +126,9 @@ def test_assert_PASS_failure(capsys):
     with pytest.raises(AssertionError):
         assert_PASS(results)
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n"
 
-
-def test_assert_PASS_ignore_error_true(capsys):
+def test_assert_PASS_ignore_error_true():
     error_msg = "ERROR message"
-    pass_reason = "with a good font..."
     ignore = "an error"
     results = [
         (PASS,),
@@ -163,22 +136,15 @@ def test_assert_PASS_ignore_error_true(capsys):
     ]
     assert assert_PASS(results, ignore_error=ignore) is None
 
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n{ignore}\n"
 
-
-def test_assert_PASS_ignore_error_false(capsys):
+def test_assert_PASS_ignore_error_false():
     error_msg = "ERROR message"
-    pass_reason = "with a good font..."
     results = [
         (PASS,),
         (ERROR, error_msg),
     ]
     with pytest.raises(AssertionError):
         assert_PASS(results)
-
-    captured = capsys.readouterr()
-    assert captured.out == f"Test PASS {pass_reason}\n"
 
 
 # ========================================================================


### PR DESCRIPTION
## Description
Relates to https://github.com/miguelsousa/openbakery/pull/80#discussion_r1349455458

- Updated `assert_PASS()` and `assert_SKIP()` to validate the code string of a yielded result of type `Message`.

## Checklist
- [ ] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

