### PR TITLE
Update layout_valid_feature_tags checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `com.google.fonts/check/mandatory_glyphs`: Improved the check's resilience to edge cases that could result in ERRORs (https://github.com/miguelsousa/openbakery/pull/38).
 - `-L`/`--list-checks` option that can be used with subcommands. Previously this option only worked if a path to an input file was also provided in the command line (https://github.com/miguelsousa/openbakery/pull/35).
 - Summary statistics on HTML reporter (https://github.com/fonttools/fontbakery/issues/3997).
+- `com.google.fonts/check/layout_valid_feature_tags`: Updated the check to allow valid private-use feature tags (https://github.com/miguelsousa/openbakery/pull/101)
 
 ## [0.1.0] - 2023-06-11
 

--- a/Lib/openbakery/profiles/layout.py
+++ b/Lib/openbakery/profiles/layout.py
@@ -28,6 +28,9 @@ DEPRECATED_TAGS = ["hngl", "opbd", "size"]
         Incorrect tags can be indications of typos, leftover debugging code or
         questionable approaches, or user error in the font editor. Such typos can
         cause features and language support to fail to work as intended.
+
+        Font vendors may use private tags to identify private features. These tags
+        must be four uppercase letters (A-Z) with no punctuation, spaces, or numbers.
     """,
     proposal="https://github.com/googlefonts/fontbakery/issues/3355",
     severity=8,
@@ -44,7 +47,8 @@ def com_google_fonts_check_layout_valid_feature_tags(ttFont):
     bad_tags = set()
     for tag in feature_tags(ttFont):
         if tag not in acceptable_tags:
-            bad_tags.add(tag)
+            if not tag.isupper() or len(tag) > 4:
+                bad_tags.add(tag)
     if bad_tags:
         yield FAIL, Message(
             "bad-feature-tags",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cmarkgfm==2022.10.27
 collidoscope==0.6.5
 defcon==0.10.3
 dehinter==4.0.0
-fontTools[ufo,lxml,unicode]==4.45.1
+fontTools[ufo,lxml,unicode]==4.49.0
 font-v==2.1.0
 freetype-py==2.3.0  # pinned for now. See: https://github.com/googlefonts/fontbakery/issues/4143
 gflanguages==0.5.10

--- a/tests/profiles/layout_test.py
+++ b/tests/profiles/layout_test.py
@@ -1,3 +1,4 @@
+from fontTools.ttLib import TTFont
 from openbakery.status import FAIL
 from openbakery.codetesting import (
     assert_PASS,
@@ -14,9 +15,17 @@ def test_check_layout_valid_feature_tags():
         layout_profile, "com.google.fonts/check/layout_valid_feature_tags"
     )
 
+    # test font with valid, registered feature tags.
     font = TEST_FILE("nunito/Nunito-Regular.ttf")
     assert_PASS(check(font))
 
+    # test font with valid, private use feature tags.
+    # change font's feature tag to have non-registered, all uppercase private tags
+    font_obj = TTFont(font)
+    font_obj["GSUB"].table.FeatureList.FeatureRecord[0].FeatureTag = "TEST"
+    assert_PASS(check(font_obj))
+
+    # test font with invalid feature tags: not registered, and not all uppercase.
     font = TEST_FILE("rosarivo/Rosarivo-Regular.ttf")
     assert_results_contain(check(font), FAIL, "bad-feature-tags")
 


### PR DESCRIPTION
## `layout_valid_feature_tags`:

According to the [OpenType Spec here](https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags), private-use feature tags are valid if they use four all-uppercase letters:
> The tag space of tags consisting of four uppercase letters (A-Z) with no punctuation, spaces, or numbers, is reserved as a vendor space. Font vendors may use such tags to identify private features. For example, the feature tag PKRN might designate a private feature that may be used to kern punctuation marks.

However, it seems that openbakery does not take this into consideration. This PR is to make openbakery more flexible when testing feature tags that are not registered, but use the correct format to be identified as private-use tags.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

