### PR TITLE
update code-tests to be able to use newer axisregistry version 0.4.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-axisregistry==0.4.5
+axisregistry==0.4.8
 beautifulsoup4==4.12.3
 beziers==0.5.0
 cmarkgfm==2024.1.14

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ ufo_sources_extras = [
 
 googlefonts_extras = (
     [
-        "axisregistry>=0.3.0",
+        "axisregistry>=0.4.8",
         "beautifulsoup4",  # For parsing registered vendor IDs from Microsoft's webpage
         "dehinter>=3.1.0",  # 3.1.0 added dehinter.font.hint function
         "font-v",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -2887,23 +2887,31 @@ def test_check_metadata_category():
         # Open Sans' origin is Light so this should pass
         (
             TEST_FILE("varfont/OpenSans[wdth,wght].ttf"),
-            {2: "Regular", 17: "Light"},
+            {
+                NameID.FONT_SUBFAMILY_NAME: "Regular",
+                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Light",
+            },
             PASS,
         ),
         (
             TEST_FILE("varfont/OpenSans[wdth,wght].ttf"),
-            {2: "Regular", 17: "Condensed Light"},
+            {
+                NameID.FONT_SUBFAMILY_NAME: "Regular",
+                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Condensed Light",
+            },
             FAIL,
         ),
-        (TEST_FILE("varfont/RobotoSerif[GRAD,opsz,wdth,wght].ttf"), {}, PASS),
+        (TEST_FILE("varfont/RobotoSerif[GRAD,opsz,wdth,wght].ttf"), {}, FAIL),
         # Roboto Serif has an opsz axes so this should pass
         (
             TEST_FILE("varfont/RobotoSerif[GRAD,opsz,wdth,wght].ttf"),
             {
-                NameID.FONT_FAMILY_NAME: "Roboto Serif 20pt",
+                NameID.FONT_FAMILY_NAME: "Roboto Serif",
                 NameID.FONT_SUBFAMILY_NAME: "Regular",
-                NameID.TYPOGRAPHIC_FAMILY_NAME: "Roboto Serif",
-                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "20pt Regular",
+                NameID.FULL_FONT_NAME: "Roboto Serif Regular",
+                NameID.POSTSCRIPT_NAME: "RobotoSerif-Regular",
+                NameID.TYPOGRAPHIC_FAMILY_NAME: None,
+                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: None,
             },
             PASS,
         ),


### PR DESCRIPTION
backporting from https://github.com/fonttools/fontbakery/pull/4527

(followup to PR #102)