### PR TITLE
Enable Python v3.12 and drop v3.8

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
With the imminent first release of Python v3.13, v3.8 is also reaching its EOL. See [status of Python versions](https://devguide.python.org/versions/).

Enable Python v3.12 and drop v3.8.
