### PR TITLE
Update unsupported-tables to fail on COLRv1 table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `com.google.fonts/check/family/panose_familytype` and `com.google.fonts/check/family/panose_proportion`: Failures have been downgraded to warnings (https://github.com/fonttools/fontbakery/issues/4192).
 - `com.adobe.fonts/check/postscript_name_characters`: Added underscore (`_` U+005F) to the set of characters allowed in PostScript name strings (https://github.com/miguelsousa/openbakery/pull/90).
 - Removed the `fontval` profile (https://github.com/miguelsousa/openbakery/pull/141).
-- `com.adobe.fonts/check/unsupported_tables`: Added COLR and CPAL tables to SUPPORTED_TABLES (https://github.com/miguelsousa/openbakery/pull/205)
+- `com.adobe.fonts/check/unsupported_tables`: Added COLR and CPAL tables to SUPPORTED_TABLES, added extra check to fail for COLRv1 (and pass for COLRv0). (https://github.com/miguelsousa/openbakery/pull/205)
 
 ### Fixed
 

--- a/Lib/openbakery/profiles/adobefonts.py
+++ b/Lib/openbakery/profiles/adobefonts.py
@@ -471,6 +471,12 @@ def com_adobe_fonts_check_unsupported_tables(ttFont):
     font_tables.discard("GlyphOrder")  # pseudo-table created by FontTools
     unsupported_tables = sorted(font_tables - SUPPORTED_TABLES)
 
+    # check if there is a COLR version 1 table specifically.
+    # COLR v0 is supported, COLR v1 is not supported.
+    if "COLR" in font_tables:
+        if ttFont["COLR"].version == 1:
+            unsupported_tables.append("COLRv1")
+
     if unsupported_tables:
         unsupported_list = "".join(f"* {tag}\n" for tag in unsupported_tables)
         yield FAIL, Message(

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -183,9 +183,15 @@ def test_check_unsupported_tables():
     msg = assert_PASS(check(ttFont))
     assert msg == "No unsupported tables were found."
 
-    ttFont = TTFont(TEST_FILE("color_fonts/noto-glyf_colr_1.ttf"))
+    # AmiriQuranColored.ttf has a COLRv0 table, which is supported.
+    ttFont = TTFont(TEST_FILE("color_fonts/AmiriQuranColored.ttf"))
     msg = assert_PASS(check(ttFont))
     assert msg == "No unsupported tables were found."
+
+    # noto-glyf_color_1.ttf has a COLRv1 table, which is not supported.
+    ttFont = TTFont(TEST_FILE("color_fonts/noto-glyf_colr_1.ttf"))
+    msg = assert_results_contain(check(ttFont), FAIL, "unsupported-tables")
+    assert "COLRv1" in msg
 
     ttFont = TTFont(TEST_FILE("hinting/Roboto-VF.ttf"))
     msg = assert_results_contain(check(ttFont), FAIL, "unsupported-tables")


### PR DESCRIPTION
## Description
Relates to #205 

Updated the `unsupported_tables` check in the Adobe Fonts profile to fail if there is a COLRv1 table. Currently, COLRv0 is supported while COLRv1 is not. 

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

