### PR TITLE
Validate VF Instance PostScript names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `com.adobe.fonts/check/postscript_name_characters`: Added underscore (`_` U+005F) to the set of characters allowed in PostScript name strings (https://github.com/miguelsousa/openbakery/pull/90).
 - Removed the `fontval` profile (https://github.com/miguelsousa/openbakery/pull/141).
 - `com.adobe.fonts/check/unsupported_tables`: Added COLR and CPAL tables to SUPPORTED_TABLES, added extra check to fail for COLRv1 (and pass for COLRv0). (https://github.com/miguelsousa/openbakery/pull/205)
+- `com.adobe.fonts/check/varfont/valid_postscript_nameid`: This check now also validates the value of a postscriptName (using shared code from `com.adobe.fonts/check/postscript_name_characters`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `notofonts` extra (https://github.com/miguelsousa/openbakery/pull/37).
 - `com.thetypefounders/check/features_default_languagesystem`: Checks if a default languagesystem statement is present in feature files and warns if the compiler will not insert one automatically (https://github.com/fonttools/fontbakery/issues/4011).
 - `com.adobe.fonts/check/cff_ascii_strings`: Checks if all strings in a font's CFF table top dict fit in the range of ASCII values (https://github.com/miguelsousa/openbakery/issues/128)
+- `com.adobe.fonts/check/varfont/valid_instance_postscript_name`: This check validates all instances' postscript names in a VF (using shared code from `com.adobe.fonts/check/postscript_name_characters`)
 
 ### Changed
 
@@ -38,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `com.adobe.fonts/check/postscript_name_characters`: Added underscore (`_` U+005F) to the set of characters allowed in PostScript name strings (https://github.com/miguelsousa/openbakery/pull/90).
 - Removed the `fontval` profile (https://github.com/miguelsousa/openbakery/pull/141).
 - `com.adobe.fonts/check/unsupported_tables`: Added COLR and CPAL tables to SUPPORTED_TABLES, added extra check to fail for COLRv1 (and pass for COLRv0). (https://github.com/miguelsousa/openbakery/pull/205)
-- `com.adobe.fonts/check/varfont/valid_postscript_nameid`: This check now also validates the value of a postscriptName (using shared code from `com.adobe.fonts/check/postscript_name_characters`)
 
 ### Fixed
 

--- a/Lib/openbakery/profiles/adobefonts.py
+++ b/Lib/openbakery/profiles/adobefonts.py
@@ -67,6 +67,7 @@ SET_EXPLICIT_CHECKS = {
     "com.adobe.fonts/check/varfont/valid_axis_nameid",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # IS_OVERRIDDEN
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
+    "com.adobe.fonts/check/varfont/valid_instance_postscript_name",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
     "com.google.fonts/check/varfont/bold_wght_coord",  # IS_OVERRIDDEN
     "com.google.fonts/check/varfont/regular_ital_coord",  # IS_OVERRIDDEN

--- a/Lib/openbakery/profiles/fvar.py
+++ b/Lib/openbakery/profiles/fvar.py
@@ -447,7 +447,9 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
         )
         passed = False
 
-    valid_postscript_nameids = list(set(font_postscript_nameids) - set(invalid_postscript_nameids))
+    valid_postscript_nameids = list(
+        set(font_postscript_nameids) - set(invalid_postscript_nameids)
+    )
     for nameid in valid_postscript_nameids:
         inst_name = str(name_table.getDebugName(nameid))
         if not valid_postscript_name(inst_name):
@@ -456,12 +458,15 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
         if bad_psnames_count := len(bad_psnames) > 0:
             yield FAIL, Message(
                 "bad-instance-psname-characters",
-                f"The following instance PostScript name{'s' if bad_psnames_count != 1 else ''} "
-                f"contain{'s' if bad_psnames_count == 1 else ''} disallowed characters:\n {bad_psnames}",
+                f"The following instance PostScript "
+                f"name{'s' if bad_psnames_count != 1 else ''} "
+                f"contain{'s' if bad_psnames_count == 1 else ''} "
+                f"disallowed characters:\n {bad_psnames}",
             )
         else:
             yield PASS, Message(
-                "psname-characters-ok", "PostScript name contains only allowed characters."
+                "psname-characters-ok",
+                "PostScript name contains only allowed characters.",
             )
 
     if passed:

--- a/Lib/openbakery/profiles/fvar.py
+++ b/Lib/openbakery/profiles/fvar.py
@@ -417,9 +417,6 @@ def com_adobe_fonts_check_varfont_valid_subfamily_nameid(ttFont, has_name_table)
 def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table):
     """Validates that the value of postScriptNameID used by each InstanceRecord
     is 6, 0xFFFF, or greater than 255 and less than 32768."""
-    from openbakery.profiles.name import valid_postscript_name
-
-    bad_psnames = []
 
     if not has_name_table:
         yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
@@ -447,29 +444,58 @@ def com_adobe_fonts_check_varfont_valid_postscript_nameid(ttFont, has_name_table
         )
         passed = False
 
-    valid_postscript_nameids = list(
-        set(font_postscript_nameids) - set(invalid_postscript_nameids)
-    )
-    for nameid in valid_postscript_nameids:
-        inst_name = str(name_table.getDebugName(nameid))
-        if not valid_postscript_name(inst_name):
-            bad_psnames.append(inst_name)
-
-        if bad_psnames_count := len(bad_psnames) > 0:
-            yield FAIL, Message(
-                "bad-instance-psname-characters",
-                f"The following instance PostScript "
-                f"name{'s' if bad_psnames_count != 1 else ''} "
-                f"contain{'s' if bad_psnames_count == 1 else ''} "
-                f"disallowed characters:\n {bad_psnames}",
-            )
-        else:
-            yield PASS, Message(
-                "psname-characters-ok",
-                "PostScript name contains only allowed characters.",
-            )
-
     if passed:
+        yield PASS, "All postScriptNameID values are valid."
+
+
+@check(
+    id="com.adobe.fonts/check/varfont/valid_instance_postscript_name",
+    rationale="""
+        According to the 'name' documentation in the OpenType Spec
+        https://learn.microsoft.com/en-us/typography/opentype/spec/name
+
+        Postscript names may contain only the characters a-z A-Z 0-9 - and _
+        This check validates the postscript names of a VF's instances specifically.
+    """,
+    conditions=["is_variable_font"],
+    proposal="https://github.com/googlefonts/fontbakery/issues/3704",
+)
+def com_adobe_fonts_check_varfont_valid_instance_postscript_name(
+    ttFont, has_name_table
+):
+    """Validates that all instances in a VF have valid PostScript names."""
+    from openbakery.profiles.name import valid_postscript_name
+
+    if not has_name_table:
+        yield FAIL, Message("lacks-table", "Font lacks 'name' table.")
+        return
+
+    font_instance_postscript_records = [
+        {
+            "ps_name": str(ttFont["name"].getDebugName(inst.postscriptNameID)),
+            "coords": inst.coordinates,
+        }
+        for inst in ttFont["fvar"].instances
+    ]
+
+    bad_psname_msg_arr = []
+    for record in font_instance_postscript_records:
+        inst_name = record["ps_name"]
+        if not valid_postscript_name(inst_name):
+            bad_psname_msg_arr.append(
+                f"'{inst_name}' at coordinates {record['coords']}\n"
+            )
+
+    if bad_psnames_count := len(bad_psname_msg_arr):
+        yield FAIL, Message(
+            "bad-instance-psname-characters",
+            f"The following VF instance PostScript "
+            f"name{'s' if bad_psnames_count != 1 else ''} at the "
+            f"specified coordinates contain{'s' if bad_psnames_count == 1 else ''} "
+            f"disallowed characters:\n"
+            f"{''.join(bad_psname_msg_arr)}",
+        )
+    else:
         yield PASS, "All postScriptNameID values are valid."
 
 

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -419,9 +419,12 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
 
 def valid_postscript_name(postscript_name):
+    """Validates the value of a given postscript name.
+    A postscript name may contain only the characters a-z A-Z 0-9 - and _
+
+    Returns True if valid, False otherwise"""
     import re
 
-    # <Postscript name> may contain only the characters a-z A-Z 0-9 - and _
     bad_psname = re.compile("[^A-Za-z0-9-_]")
     if bad_psname.search(postscript_name):
         return False
@@ -431,6 +434,12 @@ def valid_postscript_name(postscript_name):
 
 @check(
     id="com.adobe.fonts/check/postscript_name_characters",
+    rationale="""
+        According to the 'name' documentation in the OpenType Spec
+        https://learn.microsoft.com/en-us/typography/opentype/spec/name
+
+        Postscript names may contain only the characters a-z A-Z 0-9 - and _
+    """,
     proposal="https://github.com/miguelsousa/openbakery/issues/62",
 )
 def com_adobe_fonts_check_postscript_name_characters(ttFont):

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -420,6 +420,7 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
 
 def valid_postscript_name(postscript_name):
     import re
+
     # <Postscript name> may contain only the characters a-z A-Z 0-9 - and _
     bad_psname = re.compile("[^A-Za-z0-9-_]")
     if bad_psname.search(postscript_name):
@@ -435,6 +436,7 @@ def valid_postscript_name(postscript_name):
 def com_adobe_fonts_check_postscript_name_characters(ttFont):
     """PostScript name contains only allowed characters?"""
     from openbakery.utils import get_name_entry_strings
+
     bad_entry_count = 0
 
     for string in get_name_entry_strings(ttFont, NameID.POSTSCRIPT_NAME):

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -418,21 +418,27 @@ def com_google_fonts_check_name_match_familyname_fullfont(ttFont):
         yield PASS, "Full font name begins with the font family name."
 
 
+def valid_postscript_name(postscript_name):
+    import re
+    # <Postscript name> may contain only the characters a-z A-Z 0-9 - and _
+    bad_psname = re.compile("[^A-Za-z0-9-_]")
+    if bad_psname.search(postscript_name):
+        return False
+    else:
+        return True
+
+
 @check(
     id="com.adobe.fonts/check/postscript_name_characters",
     proposal="https://github.com/miguelsousa/openbakery/issues/62",
 )
 def com_adobe_fonts_check_postscript_name_characters(ttFont):
     """PostScript name contains only allowed characters?"""
-    import re
     from openbakery.utils import get_name_entry_strings
-
     bad_entry_count = 0
 
-    # <Postscript name> may contain only the characters a-z A-Z 0-9 - and _
-    bad_psname = re.compile("[^A-Za-z0-9-_]")
     for string in get_name_entry_strings(ttFont, NameID.POSTSCRIPT_NAME):
-        if bad_psname.search(string):
+        if not valid_postscript_name(string):
             bad_entry_count += 1
             yield FAIL, Message(
                 "bad-psname-characters",

--- a/Lib/openbakery/profiles/name.py
+++ b/Lib/openbakery/profiles/name.py
@@ -425,8 +425,8 @@ def valid_postscript_name(postscript_name):
     Returns True if valid, False otherwise"""
     import re
 
-    bad_psname = re.compile("[^A-Za-z0-9-_]")
-    if bad_psname.search(postscript_name):
+    disallowed_chars_re = re.compile("[^A-Za-z0-9-_]")
+    if disallowed_chars_re.search(postscript_name):
         return False
     else:
         return True

--- a/Lib/openbakery/profiles/opentype.py
+++ b/Lib/openbakery/profiles/opentype.py
@@ -86,6 +86,7 @@ OPENTYPE_PROFILE_CHECKS = [
     "com.adobe.fonts/check/varfont/valid_axis_nameid",
     "com.adobe.fonts/check/varfont/valid_subfamily_nameid",
     "com.adobe.fonts/check/varfont/valid_postscript_nameid",
+    "com.adobe.fonts/check/varfont/valid_instance_postscript_name",
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",
     "com.adobe.fonts/check/varfont/same_size_instance_records",
     "com.adobe.fonts/check/varfont/distinct_instance_records",

--- a/tests/profiles/adobefonts_test.py
+++ b/tests/profiles/adobefonts_test.py
@@ -62,7 +62,7 @@ def test_get_family_checks():
 def test_profile_check_set():
     """Confirm that the profile has the correct number of checks and the correct
     set of check IDs."""
-    assert len(SET_EXPLICIT_CHECKS) == 83
+    assert len(SET_EXPLICIT_CHECKS) == 84
     explicit_with_overrides = sorted(
         f"{check_id}{OVERRIDE_SUFFIX}" if check_id in OVERRIDDEN_CHECKS else check_id
         for check_id in SET_EXPLICIT_CHECKS

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -510,6 +510,14 @@ def test_check_varfont_valid_postscript_nameid():
     inst_3 = fvar_table.instances[2]
     inst_4 = fvar_table.instances[3]
 
+    # Change instance postScriptName value to invalid values
+    # (Add a space to the postScriptName)
+    ttFont["name"].setName("name with space", inst_1.postscriptNameID, 1, 0, 0)
+    msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
+    assert msg == (
+        "The following instance PostScript name contains disallowed characters:\n ['name with space']"
+    )
+
     # Change the instances' postScriptNameID to
     # 6, 0xFFFF and to the maximum and minimum allowed values
     inst_1.postscriptNameID = 6

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -510,15 +510,6 @@ def test_check_varfont_valid_postscript_nameid():
     inst_3 = fvar_table.instances[2]
     inst_4 = fvar_table.instances[3]
 
-    # Change instance postScriptName value to invalid values
-    # (Add a space to the postScriptName)
-    ttFont["name"].setName("name with space", inst_1.postscriptNameID, 1, 0, 0)
-    msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
-    assert msg == (
-        "The following instance PostScript name contains "
-        "disallowed characters:\n ['name with space']"
-    )
-
     # Change the instances' postScriptNameID to
     # 6, 0xFFFF and to the maximum and minimum allowed values
     inst_1.postscriptNameID = 6
@@ -555,6 +546,47 @@ def test_check_varfont_valid_postscript_nameid():
     # Confirm the check yields FAIL if the font doesn't have a required table
     del ttFont["name"]
     assert_results_contain(check(ttFont), FAIL, "lacks-table")
+
+
+def test_check_varfont_valid_instance_postscript_name():
+    """The value of postScriptName used by each InstanceRecord may
+    only use characters a-z A-Z 0-9 - and _"""
+    check = CheckTester(
+        opentype_profile, "com.adobe.fonts/check/varfont/valid_instance_postscript_name"
+    )
+
+    # The postScriptNameID values in the reference varfont are all valid
+    ttFont = TTFont("data/test/cabinvf/Cabin[wdth,wght].ttf")
+    msg = assert_PASS(check(ttFont), "with a good varfont...")
+    assert msg == "All postScriptNameID values are valid."
+
+    fvar_table = ttFont["fvar"]
+
+    # Change instance postScriptName value to invalid values
+    # (Change to a value containing spaces)
+    inst_1 = fvar_table.instances[0]
+    inst_1.postscriptNameID = 310
+    ttFont["name"].setName("name with space", inst_1.postscriptNameID, 1, 0, 0)
+
+    msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
+    assert msg == (
+        "The following instance PostScript name at the specified "
+        "coordinates contains disallowed characters:\n"
+        "'name with space' at coordinates {'wght': 400.0, 'wdth': 100.0}\n"
+    )
+
+    # Change another instance's postScriptName value to be invalid
+    # (Change to a value containing !)
+    inst_2 = fvar_table.instances[1]
+    inst_2.postscriptNameID = 311
+    ttFont["name"].setName("another-invalid!name", inst_2.postscriptNameID, 1, 0, 0)
+    msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
+    assert msg == (
+        "The following instance PostScript names at the specified "
+        "coordinates contain disallowed characters:\n"
+        "'name with space' at coordinates {'wght': 400.0, 'wdth': 100.0}\n"
+        "'another-invalid!name' at coordinates {'wght': 500.0, 'wdth': 100.0}\n"
+    )
 
 
 def test_check_varfont_valid_default_instance_nameids():

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -588,6 +588,11 @@ def test_check_varfont_valid_instance_postscript_name():
         "'another-invalid!name' at coordinates {'wght': 500.0, 'wdth': 100.0}\n"
     )
 
+    # Remove name table and check that the check yields FAIL
+    del ttFont["name"]
+    msg = assert_results_contain(check(ttFont), FAIL, "lacks-table")
+    assert msg == "Font lacks 'name' table."
+
 
 def test_check_varfont_valid_default_instance_nameids():
     """If an instance record is included for the default instance, then the instance's

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -562,7 +562,7 @@ def test_check_varfont_valid_instance_postscript_name():
 
     fvar_table = ttFont["fvar"]
 
-    # Change instance postScriptName value to invalid values
+    # Change VF instance postScriptName value to invalid values
     # (Change to a value containing spaces)
     inst_1 = fvar_table.instances[0]
     inst_1.postscriptNameID = 310
@@ -570,19 +570,19 @@ def test_check_varfont_valid_instance_postscript_name():
 
     msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
     assert msg == (
-        "The following instance PostScript name at the specified "
+        "The following VF instance PostScript name at the specified "
         "coordinates contains disallowed characters:\n"
         "'name with space' at coordinates {'wght': 400.0, 'wdth': 100.0}\n"
     )
 
-    # Change another instance's postScriptName value to be invalid
+    # Change another VFinstance's postScriptName value to be invalid
     # (Change to a value containing !)
     inst_2 = fvar_table.instances[1]
     inst_2.postscriptNameID = 311
     ttFont["name"].setName("another-invalid!name", inst_2.postscriptNameID, 1, 0, 0)
     msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
     assert msg == (
-        "The following instance PostScript names at the specified "
+        "The following VF instance PostScript names at the specified "
         "coordinates contain disallowed characters:\n"
         "'name with space' at coordinates {'wght': 400.0, 'wdth': 100.0}\n"
         "'another-invalid!name' at coordinates {'wght': 500.0, 'wdth': 100.0}\n"

--- a/tests/profiles/fvar_test.py
+++ b/tests/profiles/fvar_test.py
@@ -515,7 +515,8 @@ def test_check_varfont_valid_postscript_nameid():
     ttFont["name"].setName("name with space", inst_1.postscriptNameID, 1, 0, 0)
     msg = assert_results_contain(check(ttFont), FAIL, "bad-instance-psname-characters")
     assert msg == (
-        "The following instance PostScript name contains disallowed characters:\n ['name with space']"
+        "The following instance PostScript name contains "
+        "disallowed characters:\n ['name with space']"
     )
 
     # Change the instances' postScriptNameID to


### PR DESCRIPTION
## Description

We need to validate the PostScript names of variable fonts instances.

This PR adds a new check `com.adobe.fonts/check/varfont/valid_instance_postscript_name` check that validates the PostScript name strings of VF named instances.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

