### PR TITLE
Convert `Path` object to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Summary statistics on HTML reporter (https://github.com/fonttools/fontbakery/issues/3997).
 - `com.google.fonts/check/layout_valid_feature_tags`: Updated the check to allow valid private-use feature tags (https://github.com/miguelsousa/openbakery/pull/101).
 - Implemented several fixes to enable support for Symbol-encoded fonts (https://github.com/miguelsousa/openbakery/pull/249).
+- `com.adobe.fonts/check/freetype_rasterizer`: Fixed crash that happens when the font file path is a `pathlib.Path` object; `freetype-py` only supports `str` paths (https://github.com/miguelsousa/openbakery/pull/251).
 
 ## [0.1.0] - 2023-06-11
 

--- a/Lib/openbakery/codetesting.py
+++ b/Lib/openbakery/codetesting.py
@@ -102,6 +102,7 @@ class CheckTester:
         from fontTools.ttLib import TTFont
         from openbakery.profiles.googlefonts_conditions import family_metadata
         from glyphsLib import GSFont
+        from pathlib import Path
         import os
 
         if isinstance(values, str):
@@ -123,6 +124,8 @@ class CheckTester:
                 }
             else:
                 values = {"font": values, "fonts": [values], "ufo": values}
+        elif isinstance(values, Path):
+            values = {"font": values, "fonts": [values], "ufo": values}
         elif isinstance(values, TTFont):
             values = {
                 "font": values.reader.file.name,

--- a/Lib/openbakery/profiles/universal.py
+++ b/Lib/openbakery/profiles/universal.py
@@ -1652,6 +1652,10 @@ def com_adobe_fonts_check_freetype_rasterizer(font):
     """Ensure that the font can be rasterized by FreeType."""
     import freetype
     from freetype.ft_errors import FT_Exception
+    from pathlib import Path
+
+    if isinstance(font, Path):
+        font = str(font)
 
     try:
         face = freetype.Face(font)

--- a/tests/profiles/universal_test.py
+++ b/tests/profiles/universal_test.py
@@ -1194,11 +1194,16 @@ def test_check_gpos7():
 
 def test_check_freetype_rasterizer():
     """Ensure that the font can be rasterized by FreeType."""
+    from pathlib import Path
+
     check = CheckTester(universal_profile, "com.adobe.fonts/check/freetype_rasterizer")
 
     PASS_MSG = "Font can be rasterized by FreeType."
 
     font = TEST_FILE("cabin/Cabin-Regular.ttf")
+    assert assert_PASS(check(font)) == PASS_MSG
+
+    font = Path(TEST_FILE("cabin/Cabin-Regular.ttf"))
     assert assert_PASS(check(font)) == PASS_MSG
 
     font = TEST_FILE("ancho/AnchoGX.ttf")


### PR DESCRIPTION
Fixes `Failed with AttributeError: 'PosixPath' object has no attribute 'encode'` in **freetype_rasterizer** check.

## Checklist
- [x] update `CHANGELOG.md`
- [x] wait for the tests to pass
- [x] request a review

