### PR TITLE
Pin opentypespec version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ except IOError:
 FONTTOOLS_VERSION = ">=4.39.0"  # Python 3.8+ required
 UFO2FT_VERSION = ">=2.25.2"  # 2.25.2 updated the script lists for Unicode 14.0
 VHARFBUZZ_VERSION = ">=0.2.0"  # 0.2.0 had an API update
-OPENTYPESPEC_VERSION = "==1.9.2"  # Pinned for consistent tag validation
 
 # Profile-specific dependencies:
 shaping_extras = [


### PR DESCRIPTION
## Description
I believe it will be helpful for us to start pinning the opentypespec version as some of our test results heavily depend on that library. This feels especially important when using openbakery as a dependency in other libraries — when we update openbakery, we should also be able to get a stable version of opentypespec from that install. I noticed that in one of our libraries that uses openbakery, opentypespec was not being bumped from 1.9.1 to 1.9.2, which did show different test results. For now, I have pinned opentypespec in that other library, but I think it'd be nice if openbakery handled that itself.

In this PR, I pinned the opentypespec version to accept either a specific version or higher. Let me know what you think!

## Checklist
- [ ] update `CHANGELOG.md` — dependency change, not sure if we need a bullet point here
- [ ] wait for the tests to pass
- [ ] request a review

