### PR TITLE
Remove axisregistry dependency

### DIFF
--- a/.github/workflows/install_run.yml
+++ b/.github/workflows/install_run.yml
@@ -118,7 +118,6 @@ jobs:
     - name: Run Google Fonts checks
       run: >-
         openbakery googlefonts
-        -c canonical_filename
         -c vendor_id
         -c glyph_coverage
         -c name/license
@@ -140,7 +139,6 @@ jobs:
         -c style_linking
         -c consistent_axes
         -c metadata/parses
-        -c usweightclass
         data/test/source-sans-pro/VAR/SourceSansVariable-Roman.ttf
 
     - name: Install `notofonts` extra
@@ -156,7 +154,6 @@ jobs:
         -c alien_codepoints
         -c tnum_horizontal_metrics
         -c control_chars
-        -c canonical_filename
         data/test/notosanskhudawadi/NotoSansKhudawadi-Regular.ttf
 
     - name: Uninstall OpenBakery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `fontval` profile (https://github.com/miguelsousa/openbakery/pull/141).
 - `com.adobe.fonts/check/unsupported_tables`: Added COLR and CPAL tables to SUPPORTED_TABLES, added extra check to fail for COLRv1 (and pass for COLRv0). (https://github.com/miguelsousa/openbakery/pull/205)
 - Removed the `protobuf` dependency, along with all checks that depended on parsing `METADATA.pb` files. This includes the entire `com.google.fonts/check/metadata/*` family of checks (and their related conditions, test fixtures, and `*.proto` schemas) (https://github.com/miguelsousa/openbakery/pull/345).
-- Replaced `black` and `flake8` with `ruff` for code formatting and linting.
+- Removed the `axisregistry` dependency, along with the seven `googlefonts`-profile checks that relied on it: `com.google.fonts/check/canonical_filename`, `com.google.fonts/check/usweightclass`, `com.google.fonts/check/font_names`, `com.google.fonts/check/STAT`, `com.google.fonts/check/fvar_instances`, `com.google.fonts/check/gf_axisregistry/fvar_axis_defaults`, and `com.google.fonts/check/STAT/gf_axisregistry` (along with their backing `GFAxisRegistry` and `expected_font_names` conditions) (https://github.com/miguelsousa/openbakery/pull/367).
+- Replaced `black` and `flake8` with `ruff` for code formatting and linting (https://github.com/miguelsousa/openbakery/pull/348).
 
 ### Fixed
 

--- a/Lib/openbakery/profiles/fontwerk.py
+++ b/Lib/openbakery/profiles/fontwerk.py
@@ -29,7 +29,6 @@ profile.configuration_defaults = {
 def leave_this_one_out(checkid):
     CHECKS_NOT_TO_INCLUDE = [
         # don't run these checks on the Fontwerk profile:
-        "com.google.fonts/check/canonical_filename",
         "com.google.fonts/check/vendor_id",
         "com.google.fonts/check/fstype",
         "com.google.fonts/check/gasp",

--- a/Lib/openbakery/profiles/googlefonts.py
+++ b/Lib/openbakery/profiles/googlefonts.py
@@ -11,7 +11,6 @@ from openbakery.utils import (
     add_check_overrides,
     bullet_list,
     filesize_formatting,
-    markdown_table,
 )
 from openbakery.message import Message, KEEP_ORIGINAL_MESSAGE
 from openbakery.fonts_profile import profile_factory
@@ -23,7 +22,6 @@ from openbakery.constants import (
     UnicodeEncodingID,
     LATEST_TTFAUTOHINT_VERSION,
 )
-from openbakery.utils import exit_with_install_instructions
 
 profile_imports = (
     (".", ("googlefonts_conditions", "universal", "outline", "shaping", "ufo_sources")),
@@ -95,8 +93,6 @@ REPO_CHECKS = [
 
 FONT_FILE_CHECKS = [
     "com.google.fonts/check/glyph_coverage",
-    "com.google.fonts/check/canonical_filename",
-    "com.google.fonts/check/usweightclass",
     "com.google.fonts/check/fstype",
     "com.google.fonts/check/vendor_id",
     "com.google.fonts/check/ligature_carets",
@@ -118,13 +114,11 @@ FONT_FILE_CHECKS = [
     "com.google.fonts/check/hinting_impact",
     "com.google.fonts/check/file_size",
     "com.google.fonts/check/varfont/has_HVAR",
-    "com.google.fonts/check/font_names",
     "com.google.fonts/check/gasp",
     "com.google.fonts/check/name/mandatory_entries",
     "com.google.fonts/check/name/copyright_length",
     "com.google.fonts/check/fontdata_namecheck",
     "com.google.fonts/check/name/ascii_only_entries",
-    "com.google.fonts/check/fvar_instances",
     "com.google.fonts/check/old_ttfautohint",
     "com.google.fonts/check/vttclean",
     "com.google.fonts/check/aat",
@@ -140,8 +134,6 @@ FONT_FILE_CHECKS = [
     "com.google.fonts/check/varfont/consistent_axes",
     "com.google.fonts/check/varfont/unsupported_axes",
     "com.google.fonts/check/varfont/grade_reflow",
-    "com.google.fonts/check/gf_axisregistry/fvar_axis_defaults",
-    "com.google.fonts/check/STAT/gf_axisregistry",
     "com.google.fonts/check/STAT/axis_order",
     "com.google.fonts/check/mandatory_avar_table",
     "com.google.fonts/check/missing_small_caps_glyphs",
@@ -150,7 +142,6 @@ FONT_FILE_CHECKS = [
     "com.google.fonts/check/meta/script_lang_tags",
     "com.google.fonts/check/no_debugging_tables",
     "com.google.fonts/check/render_own_name",
-    "com.google.fonts/check/STAT",
     "com.google.fonts/check/colorfont_tables",
     "com.google.fonts/check/color_cpal_brightness",
     "com.google.fonts/check/empty_glyph_on_gid1_for_colrv0",
@@ -168,47 +159,6 @@ GOOGLEFONTS_PROFILE_CHECKS = (
     + FONT_FILE_CHECKS
     + GLYPHSAPP_CHECKS
 )
-
-
-@check(
-    id="com.google.fonts/check/canonical_filename",
-    rationale="""
-        A font's filename must be composed as "<familyname>-<stylename>.ttf":
-
-        - Nunito-Regular.ttf
-
-        - Oswald-BoldItalic.ttf
-
-
-        Variable fonts must list the axis tags in alphabetical order in
-        square brackets and separated by commas:
-
-        - Roboto[wdth,wght].ttf
-
-        - Familyname-Italic[wght].ttf
-    """,
-    proposal="legacy:check/001",
-)
-def com_google_fonts_check_canonical_filename(ttFont):
-    """Checking file is named canonically."""
-    try:
-        from axisregistry import build_filename
-
-        current_filename = os.path.basename(ttFont.reader.file.name)
-        expected_filename = build_filename(ttFont)
-    except ImportError:
-        exit_with_install_instructions("googlefonts")
-
-    if current_filename != expected_filename:
-        yield (
-            FAIL,
-            Message(
-                "bad-filename",
-                f'Expected "{expected_filename}. Got {current_filename}.',
-            ),
-        )
-    else:
-        yield PASS, f'Font filename is correct, "{current_filename}".'
 
 
 @check(
@@ -830,100 +780,6 @@ def com_google_fonts_check_name_unwanted_chars(ttFont):
                 " trademark symbols in name table entries of this font."
             ),
         )
-
-
-@check(
-    id="com.google.fonts/check/usweightclass",
-    conditions=["expected_font_names"],
-    rationale="""
-        Google Fonts expects variable fonts, static ttfs and static otfs to have
-        differing OS/2 usWeightClass values.
-
-        - For Variable Fonts, Thin-Black must be 100-900
-
-        - For static ttfs, Thin-Black can be 100-900 or 250-900
-
-        - For static otfs, Thin-Black must be 250-900
-
-        If static otfs are set lower than 250, text may appear blurry in
-        legacy Windows applications.
-
-        Glyphsapp users can change the usWeightClass value of an instance by adding
-        a 'weightClass' customParameter.
-    """,
-    proposal="legacy:check/020",
-)
-def com_google_fonts_check_usweightclass(ttFont, expected_font_names):
-    """
-    Check the OS/2 usWeightClass is appropriate for the font's best SubFamily name.
-    """
-    from openbakery.profiles.shared_conditions import is_ttf, is_cff, is_variable_font
-
-    passed = True
-    value = ttFont["OS/2"].usWeightClass
-    expected_value = expected_font_names["OS/2"].usWeightClass
-    style_name = ttFont["name"].getBestSubFamilyName()
-    has_expected_value = value == expected_value
-    fail_message = (
-        "Best SubFamily name is '{}'. Expected OS/2 usWeightClass is {}, got {}."
-    )
-    if is_variable_font(ttFont):
-        if not has_expected_value:
-            passed = False
-            yield (
-                FAIL,
-                Message(
-                    "bad-value", fail_message.format(style_name, expected_value, value)
-                ),
-            )
-    # overrides for static Thin and ExtaLight fonts
-    # for static ttfs, we don't mind if Thin is 250 and ExtraLight is 275.
-    # However, if the values are incorrect we will recommend they set Thin
-    # to 100 and ExtraLight to 250.
-    # for static otfs, Thin must be 250 and ExtraLight must be 275
-    elif "Thin" in style_name:
-        if is_ttf(ttFont) and value not in [100, 250]:
-            passed = False
-            yield (
-                FAIL,
-                Message(
-                    "bad-value", fail_message.format(style_name, expected_value, value)
-                ),
-            )
-        if is_cff(ttFont) and value != 250:
-            passed = False
-            yield (
-                FAIL,
-                Message("bad-value", fail_message.format(style_name, 250, value)),
-            )
-
-    elif "ExtraLight" in style_name:
-        if is_ttf(ttFont) and value not in [200, 275]:
-            passed = False
-            yield (
-                FAIL,
-                Message(
-                    "bad-value", fail_message.format(style_name, expected_value, value)
-                ),
-            )
-        if is_cff(ttFont) and value != 275:
-            passed = False
-            yield (
-                FAIL,
-                Message("bad-value", fail_message.format(style_name, 275, value)),
-            )
-
-    elif not has_expected_value:
-        passed = False
-        yield (
-            FAIL,
-            Message(
-                "bad-value", fail_message.format(style_name, expected_value, value)
-            ),
-        )
-
-    if passed:
-        yield PASS, "OS/2 usWeightClass is good"
 
 
 @check(
@@ -2102,89 +1958,6 @@ def com_google_fonts_check_slant_direction(ttFont, uharfbuzz_blob):
         yield PASS, "Angle of 'slnt' axis looks good."
 
 
-@check(
-    id="com.google.fonts/check/font_names",
-    conditions=["expected_font_names"],
-    rationale="""
-        Google Fonts has several rules which need to be adhered to when
-        setting a font's name table. Please read:
-        https://googlefonts.github.io/gf-guide/statics.html#supported-styles
-        https://googlefonts.github.io/gf-guide/statics.html#style-linking
-        https://googlefonts.github.io/gf-guide/statics.html#unsupported-styles
-        https://googlefonts.github.io/gf-guide/statics.html#single-weight-families
-    """,
-    proposal="https://github.com/googlefonts/fontbakery/pull/3800",
-)
-def com_google_fonts_check_font_names(ttFont, expected_font_names):
-    """Check font names are correct"""
-
-    def style_names(nametable):
-        res = {}
-        for nameID in (
-            NameID.FONT_FAMILY_NAME,
-            NameID.FONT_SUBFAMILY_NAME,
-            NameID.FULL_FONT_NAME,
-            NameID.POSTSCRIPT_NAME,
-            NameID.TYPOGRAPHIC_FAMILY_NAME,
-            NameID.TYPOGRAPHIC_SUBFAMILY_NAME,
-        ):
-            rec = nametable.getName(nameID, 3, 1, 0x409)
-            if rec:
-                res[nameID] = rec.toUnicode()
-        return res
-
-    font_names = style_names(ttFont["name"])
-    expected_names = style_names(expected_font_names["name"])
-
-    name_ids = {
-        NameID.FONT_FAMILY_NAME: "Family Name",
-        NameID.FONT_SUBFAMILY_NAME: "Subfamily Name",
-        NameID.FULL_FONT_NAME: "Full Name",
-        NameID.POSTSCRIPT_NAME: "Poscript Name",
-        NameID.TYPOGRAPHIC_FAMILY_NAME: "Typographic Family Name",
-        NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Typographic Subfamily Name",
-    }
-    table = []
-    for nameID in set(font_names.keys()) | set(expected_names.keys()):
-        id_name = name_ids[nameID]
-        row = {"nameID": id_name}
-        if nameID in font_names:
-            row["current"] = font_names[nameID]
-        else:
-            row["current"] = "N/A"
-        if nameID in expected_names:
-            row["expected"] = expected_names[nameID]
-        else:
-            row["expected"] = "N/A"
-        table.append(row)
-
-    new_names = set(font_names) - set(expected_names)
-    missing_names = set(expected_names) - set(font_names)
-    same_names = set(font_names) & set(expected_names)
-
-    md_table = markdown_table(table)
-
-    passed = True
-    if new_names or missing_names:
-        passed = False
-
-    for nameID in same_names:
-        if nameID == NameID.FULL_FONT_NAME and all(
-            [
-                " Regular" in expected_names[nameID],
-                font_names[nameID] == expected_names[nameID].replace(" Regular", ""),
-            ]
-        ):
-            yield WARN, Message("lacks-regular", "Regular missing from full name")
-        elif font_names[nameID] != expected_names[nameID]:
-            passed = False
-
-    if not passed:
-        yield FAIL, Message("bad-names", f"Font names are incorrect:\n\n{md_table}")
-    else:
-        yield PASS, f"Font names are good:\n\n{md_table}"
-
-
 # FIXME!
 # Temporarily disabled since GFonts hosted Cabin files seem to have changed in ways
 # that break some of the assumptions in the check implementation below.
@@ -2772,207 +2545,6 @@ def com_google_fonts_check_aat(ttFont):
         )
     else:
         yield PASS, "There are no unwanted AAT tables."
-
-
-@check(
-    id="com.google.fonts/check/STAT",
-    conditions=["is_variable_font", "expected_font_names"],
-    rationale="""
-        Check a font's STAT table contains compulsory Axis Values which exist
-        in the Google Fonts Axis Registry.
-
-        We cannot determine what Axis Values the user will set for axes such as
-        opsz, GRAD since these axes are unique for each font so we'll skip them.
-    """,
-    proposal="https://github.com/googlefonts/fontbakery/pull/3800",
-)
-def com_google_fonts_check_stat(ttFont, expected_font_names):
-    """Check a font's STAT table contains compulsory Axis Values."""
-    if "STAT" not in ttFont:
-        yield FAIL, "Font is missing STAT table"
-        return
-
-    AXES_TO_CHECK = {
-        "CASL",
-        "CRSV",
-        "FILL",
-        "FLAR",
-        "MONO",
-        "SOFT",
-        "VOLM",
-        "wdth",
-        "wght",
-        "WONK",
-    }
-
-    def stat_axis_values(ttFont):
-        name = ttFont["name"]
-        stat = ttFont["STAT"].table
-        axes = [a.AxisTag for a in stat.DesignAxisRecord.Axis]
-        res = {}
-        if ttFont["STAT"].table.AxisValueCount == 0:
-            return res
-        axis_values = stat.AxisValueArray.AxisValue
-        for ax in axis_values:
-            # Google Fonts axis registry cannot check format 4 Axis Values
-            if ax.Format == 4:
-                continue
-            axis_tag = axes[ax.AxisIndex]
-            if axis_tag not in AXES_TO_CHECK:
-                continue
-            ax_name = name.getName(ax.ValueNameID, 3, 1, 0x409).toUnicode()
-            if ax.Format == 2:
-                value = ax.NominalValue
-            else:
-                value = ax.Value
-            res[(axis_tag, ax_name)] = {
-                "Axis": axis_tag,
-                "Name": ax_name,
-                "Flags": ax.Flags,
-                "Value": value,
-                "LinkedValue": (
-                    None if not hasattr(ax, "LinkedValue") else ax.LinkedValue
-                ),
-            }
-        return res
-
-    font_axis_values = stat_axis_values(ttFont)
-    expected_axis_values = stat_axis_values(expected_font_names)
-
-    table = []
-    for axis, name in set(font_axis_values.keys()) | set(expected_axis_values.keys()):
-        row = {}
-        key = (axis, name)
-        if key in font_axis_values:
-            row["Name"] = name
-            row["Axis"] = axis
-            row["Current Value"] = font_axis_values[key]["Value"]
-            row["Current Flags"] = font_axis_values[key]["Flags"]
-            row["Current LinkedValue"] = font_axis_values[key]["LinkedValue"]
-        else:
-            row["Name"] = name
-            row["Axis"] = axis
-            row["Current Value"] = "N/A"
-            row["Current Flags"] = "N/A"
-            row["Current LinkedValue"] = "N/A"
-        if key in expected_axis_values:
-            row["Name"] = name
-            row["Axis"] = axis
-            row["Expected Value"] = expected_axis_values[key]["Value"]
-            row["Expected Flags"] = expected_axis_values[key]["Flags"]
-            row["Expected LinkedValue"] = expected_axis_values[key]["LinkedValue"]
-        else:
-            row["Name"] = name
-            row["Axis"] = axis
-            row["Expected Value"] = "N/A"
-            row["Expected Flags"] = "N/A"
-            row["Expected LinkedValue"] = "N/A"
-        table.append(row)
-    table.sort(key=lambda k: (k["Axis"], str(k["Expected Value"])))
-    md_table = markdown_table(table)
-
-    passed = True
-    is_italic = any(a.axisTag in ["ital", "slnt"] for a in ttFont["fvar"].axes)
-    missing_ital_av = any("Italic" in r["Name"] for r in table)
-    if is_italic and missing_ital_av:
-        passed = False
-        yield FAIL, Message("missing-ital-axis-values", "Italic Axis Value missing.")
-
-    if font_axis_values != expected_axis_values:
-        passed = False
-        yield (
-            FAIL,
-            Message(
-                "bad-axis-values",
-                f"Compulsory STAT Axis Values are incorrect:\n\n {md_table}\n",
-            ),
-        )
-    if passed:
-        yield PASS, "Compulsory STAT Axis Values are correct."
-
-
-@check(
-    id="com.google.fonts/check/fvar_instances",
-    conditions=["is_variable_font", "expected_font_names"],
-    rationale="""
-        Check a font's fvar instance coordinates comply with our guidelines:
-        https://googlefonts.github.io/gf-guide/variable.html#fvar-instances
-    """,
-    proposal="https://github.com/googlefonts/fontbakery/pull/3800",
-)
-def com_google_fonts_check_fvar_instances(ttFont, expected_font_names):
-    """Check variable font instances"""
-
-    def get_instances(ttFont):
-        name = ttFont["name"]
-        fvar = ttFont["fvar"]
-        res = {}
-        for inst in fvar.instances:
-            inst_name = name.getName(inst.subfamilyNameID, 3, 1, 0x409)
-            if not inst_name:
-                continue
-            res[inst_name.toUnicode()] = inst.coordinates
-        return res
-
-    font_instances = get_instances(ttFont)
-    expected_instances = get_instances(expected_font_names)
-    table = []
-    for name in set(font_instances.keys()) | set(expected_instances.keys()):
-        row = {"Name": name}
-        if name in font_instances:
-            row["current"] = ", ".join(
-                [f"{k}={v}" for k, v in font_instances[name].items()]
-            )
-        else:
-            row["current"] = "N/A"
-        if name in expected_instances:
-            row["expected"] = ", ".join(
-                [f"{k}={v}" for k, v in expected_instances[name].items()]
-            )
-        else:
-            row["expected"] = "N/A"
-        table.append(row)
-    table = sorted(table, key=lambda k: str(k["expected"]))
-
-    missing = set(expected_instances.keys()) - set(font_instances.keys())
-    new = set(font_instances.keys()) - set(expected_instances.keys())
-    same = set(font_instances.keys()) & set(expected_instances.keys())
-    # check if instances have correct weight.
-    if all("wght" in expected_instances[i] for i in expected_instances):
-        wght_wrong = any(
-            font_instances[i]["wght"] != expected_instances[i]["wght"] for i in same
-        )
-    else:
-        wght_wrong = False
-
-    md_table = markdown_table(table)
-    if any([wght_wrong, missing, new]):
-        hints = ""
-        if missing:
-            hints += "- Add missing instances\n"
-        if new:
-            hints += "- Delete additional instances\n"
-        if wght_wrong:
-            hints += "- wght coordinates are wrong for some instances"
-        yield (
-            FAIL,
-            Message(
-                "bad-fvar-instances",
-                f"fvar instances are incorrect:\n{hints}\n{md_table}",
-            ),
-        )
-    elif any(font_instances[i] != expected_instances[i] for i in same):
-        yield (
-            WARN,
-            Message(
-                "suspicious-fvar-coords",
-                "fvar instance coordinates for non-wght axes are not the same as the fvar"
-                " defaults. This may be intentional so please check with the font author:"
-                f"\n\n{md_table}",
-            ),
-        )
-    else:
-        yield PASS, f"fvar instances are good:\n\n{md_table}"
 
 
 @check(
@@ -4628,173 +4200,6 @@ def com_google_fonts_check_varfont_grade_reflow(ttFont, config):
             PASS,
             ("No variations or kern rules vary horizontal advance along the GRAD axis"),
         )
-
-
-@check(
-    id="com.google.fonts/check/gf_axisregistry/fvar_axis_defaults",
-    rationale="""
-        Check that axis defaults have a corresponding fallback name registered at the
-        Google Fonts Axis Registry, available at
-        https://github.com/google/fonts/tree/main/axisregistry
-
-        This is necessary for the following reasons:
-
-        To get ZIP files downloads on Google Fonts to be accurate — otherwise the
-        chosen default font is not generated. The Newsreader family, for instance, has
-        a default value on the 'opsz' axis of 16pt. If 16pt was not a registered
-        fallback position, then the ZIP file would instead include another position
-        as default (such as 14pt).
-
-        For the Variable fonts to display the correct location on the specimen page.
-
-        For VF with no weight axis to be displayed at all. For instance, Ballet, which
-        has no weight axis, was not appearing in sandbox because default position on
-        'opsz' axis was 16pt, and it was not yet a registered fallback positon.
-    """,
-    conditions=["is_variable_font", "GFAxisRegistry"],
-    proposal="https://github.com/googlefonts/fontbakery/issues/3141",
-)
-def com_google_fonts_check_gf_axisregistry_fvar_axis_defaults(ttFont, GFAxisRegistry):
-    """
-    Validate defaults on fvar table match registered fallback names in GFAxisRegistry.
-    """
-
-    passed = True
-    for axis in ttFont["fvar"].axes:
-        if axis.axisTag not in GFAxisRegistry:
-            continue
-        fallbacks = GFAxisRegistry[axis.axisTag].fallback
-        if axis.defaultValue not in [f.value for f in fallbacks]:
-            passed = False
-            yield (
-                FAIL,
-                Message(
-                    "not-registered",
-                    f"The defaul value {axis.axisTag}:{axis.defaultValue} is not registered"
-                    " as an axis fallback name on the Google Axis Registry.\n\tYou should"
-                    " consider suggesting the addition of this value to the registry"
-                    " or adopted one of the existing fallback names for this axis:\n"
-                    f"\t{fallbacks}",
-                ),
-            )
-    if passed:
-        yield PASS, "OK"
-
-
-@check(
-    id="com.google.fonts/check/STAT/gf_axisregistry",
-    rationale="""
-        Check that particle names and values on STAT table match the fallback names
-        in each axis entry at the Google Fonts Axis Registry, available at
-        https://github.com/google/fonts/tree/main/axisregistry
-    """,
-    conditions=["is_variable_font", "GFAxisRegistry"],
-    proposal="https://github.com/googlefonts/fontbakery/issues/3022",
-)
-def com_google_fonts_check_STAT_gf_axisregistry_names(ttFont, GFAxisRegistry):
-    """
-    Validate STAT particle names and values match the fallback names in GFAxisRegistry.
-    """
-
-    def normalize_name(name):
-        return "".join(name.split(" "))
-
-    passed = True
-    format4_entries = False
-    if "STAT" not in ttFont:
-        yield FAIL, "Font is missing STAT table."
-        return
-    axis_value_array = ttFont["STAT"].table.AxisValueArray
-    if not axis_value_array:
-        yield (
-            FAIL,
-            Message("missing-axis-values", "STAT table is missing Axis Value Records"),
-        )
-        return
-
-    for axis_value in axis_value_array.AxisValue:
-        if axis_value.Format == 4:
-            coords = []
-            for record in axis_value.AxisValueRecord:
-                axis = ttFont["STAT"].table.DesignAxisRecord.Axis[record.AxisIndex]
-                coords.append(f"{axis.AxisTag}:{record.Value}")
-            coords = ", ".join(coords)
-
-            name_entry = ttFont["name"].getName(
-                axis_value.ValueNameID,
-                PlatformID.WINDOWS,
-                WindowsEncodingID.UNICODE_BMP,
-                WindowsLanguageID.ENGLISH_USA,
-            )
-            format4_entries = True
-            yield INFO, Message("format-4", f"'{name_entry.toUnicode()}' at ({coords})")
-            continue
-
-        axis = ttFont["STAT"].table.DesignAxisRecord.Axis[axis_value.AxisIndex]
-        if axis.AxisTag in GFAxisRegistry.keys():
-            fallbacks = GFAxisRegistry[axis.AxisTag].fallback
-            fallbacks = {f.name: f.value for f in fallbacks}
-
-            # Here we assume that it is enough to check for only the Windows,
-            # English USA entry corresponding to a given nameID. It is up to other
-            # checks to ensure all different platform/encoding entries
-            # with a given nameID are consistent in the name table.
-            name_entry = ttFont["name"].getName(
-                axis_value.ValueNameID,
-                PlatformID.WINDOWS,
-                WindowsEncodingID.UNICODE_BMP,
-                WindowsLanguageID.ENGLISH_USA,
-            )
-
-            # Here "name_entry" has the user-friendly name of the current AxisValue
-            # We want to ensure that this string shows up as a "fallback" name
-            # on the GF Axis Registry for this specific variation axis tag.
-            is_value = None
-            name = normalize_name(name_entry.toUnicode())
-            expected_names = [normalize_name(n) for n in fallbacks.keys()]
-            if hasattr(axis_value, "Value"):  # Format 1 & 3
-                is_value = axis_value.Value
-            elif hasattr(axis_value, "NominalValue"):  # Format 2
-                is_value = axis_value.NominalValue
-            if name not in expected_names:
-                expected_names = ", ".join(expected_names)
-                passed = False
-                yield (
-                    FAIL,
-                    Message(
-                        "invalid-name",
-                        f"On the font variation axis '{axis.AxisTag}',"
-                        f" the name '{name_entry.toUnicode()}'"
-                        f" is not among the expected ones ({expected_names}) according"
-                        " to the Google Fonts Axis Registry.",
-                    ),
-                )
-            elif is_value != fallbacks[name_entry.toUnicode()]:
-                passed = False
-                yield (
-                    FAIL,
-                    Message(
-                        "bad-coordinate",
-                        f"Axis Value for '{axis.AxisTag}':'{name_entry.toUnicode()}' is"
-                        f" expected to be '{fallbacks[name_entry.toUnicode()]}' but this"
-                        f" font has '{name_entry.toUnicode()}'='{axis_value.Value}'.",
-                    ),
-                )
-
-    if format4_entries:
-        yield (
-            INFO,
-            Message(
-                "format-4",
-                "The GF Axis Registry does not currently contain fallback names"
-                " for the combination of values for more than a single axis,"
-                " which is what these 'format 4' entries are designed to describe,"
-                " so this check will ignore them for now.",
-            ),
-        )
-
-    if passed:
-        yield PASS, "OK"
 
 
 @check(

--- a/Lib/openbakery/profiles/googlefonts_conditions.py
+++ b/Lib/openbakery/profiles/googlefonts_conditions.py
@@ -620,13 +620,6 @@ def production_metadata(config):
 
 
 @condition
-def GFAxisRegistry():
-    from axisregistry import AxisRegistry
-
-    return AxisRegistry()
-
-
-@condition
 def upstream_yaml(family_directory):
     fp = os.path.join(family_directory, "upstream.yaml")
     if not os.path.isfile(fp):
@@ -637,17 +630,3 @@ def upstream_yaml(family_directory):
 @condition
 def is_noto(font_familyname):
     return font_familyname.startswith("Noto ")
-
-
-@condition
-def expected_font_names(ttFont, ttFonts):
-    from axisregistry import build_name_table, build_fvar_instances, build_stat
-    from copy import deepcopy
-
-    siblings = [f for f in ttFonts if f != ttFont]
-    font_cp = deepcopy(ttFont)
-    build_name_table(font_cp, siblings=siblings)
-    if "fvar" in font_cp:
-        build_fvar_instances(font_cp)
-        build_stat(font_cp, siblings)
-    return font_cp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-axisregistry==0.4.16
 beautifulsoup4==4.14.3
 beziers==0.6.0
 cmarkgfm==2025.10.22

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ ufo_sources_extras = [
 
 googlefonts_extras = (
     [
-        "axisregistry>=0.4.8",
         "beautifulsoup4",  # For parsing registered vendor IDs from Microsoft's webpage
         "dehinter>=3.1.0",  # 3.1.0 added dehinter.font.hint function
         "font-v",

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -36,7 +36,7 @@ def test_command_check_googlefonts():
             TOOL_NAME,
             "googlefonts",
             "-c",
-            "com.google.fonts/check/canonical_filename",
+            "com.google.fonts/check/vendor_id",
             "-c",
             "stat_axis_record_for_each_axis",
             "-c",

--- a/tests/profiles/googlefonts_test.py
+++ b/tests/profiles/googlefonts_test.py
@@ -1,14 +1,12 @@
 import math
 import os
 import shutil
-from unittest.mock import patch
 
 import pytest
 from fontTools.ttLib import TTFont
 
 
 from openbakery.profiles.googlefonts import can_shape
-from openbakery.profiles.googlefonts_conditions import expected_font_names
 from openbakery.status import DEBUG, INFO, WARN, ERROR, SKIP, PASS, FAIL, ENDCHECK
 from openbakery.codetesting import (
     assert_results_contain,
@@ -25,8 +23,6 @@ from openbakery.constants import (
     PlatformID,
     WindowsEncodingID,
     WindowsLanguageID,
-    MacintoshEncodingID,
-    MacintoshLanguageID,
     OFL_BODY_TEXT,
 )
 from openbakery.profiles import googlefonts as googlefonts_profile
@@ -150,66 +146,6 @@ def test_example_checkrunner_based(cabin_regular_path):
         if status == ENDCHECK:
             assert message == WARN and last_check_message.code == "unknown"
             break
-
-
-@patch("axisregistry.build_filename", side_effect=ImportError)
-def test_extra_needed_exit(mock_import_error):
-    ttFont = TTFont(TEST_FILE("cabinvfbeta/Cabin-VF.ttf"))
-    with patch("sys.exit") as mock_exit:
-        check = CheckTester(
-            googlefonts_profile, "com.google.fonts/check/canonical_filename"
-        )
-        check(ttFont)
-        mock_exit.assert_called()
-
-
-@pytest.mark.parametrize(
-    """fp,result""",
-    [
-        (TEST_FILE("montserrat/Montserrat-Thin.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Light.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Regular.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Medium.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-SemiBold.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Bold.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraBold.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Black.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-ThinItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraLightItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-LightItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-Italic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-MediumItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-SemiBoldItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraBoldItalic.ttf"), PASS),
-        (TEST_FILE("montserrat/Montserrat-BlackItalic.ttf"), PASS),
-        (TEST_FILE("cabinvfbeta/CabinVFBeta-Italic[wght].ttf"), PASS),
-        (TEST_FILE("cabinvfbeta/CabinVFBeta.ttf"), FAIL),
-        (TEST_FILE("cabinvfbeta/Cabin-Italic.ttf"), FAIL),
-        (TEST_FILE("cabinvfbeta/Cabin-Roman.ttf"), FAIL),
-        (TEST_FILE("cabinvfbeta/Cabin-Italic-VF.ttf"), FAIL),
-        (TEST_FILE("cabinvfbeta/Cabin-Roman-VF.ttf"), FAIL),
-        (TEST_FILE("cabinvfbeta/Cabin-VF.ttf"), FAIL),
-        # axis tags are sorted
-        (TEST_FILE("cabinvfbeta/CabinVFBeta[wdth,wght].ttf"), PASS),
-        # axis tags are NOT sorted
-        (TEST_FILE("cabinvfbeta/CabinVFBeta[wght,wdth].ttf"), FAIL),
-    ],
-)
-def test_check_canonical_filename(fp, result):
-    """Files are named canonically."""
-    check = CheckTester(
-        googlefonts_profile, "com.google.fonts/check/canonical_filename"
-    )
-    ttFont = TTFont(fp)
-
-    if result == PASS:
-        assert_PASS(check(ttFont), f'with "{ttFont.reader.file.name}" ...')
-    else:
-        assert_results_contain(
-            check(ttFont), FAIL, "bad-filename", f'with "{ttFont.reader.file.name}" ...'
-        )
 
 
 @pytest.mark.skip(reason="failing due to google fonts issues")
@@ -819,56 +755,6 @@ def test_check_name_unwanted_chars():
     # Our reference Cabin Regular is know to be good here.
     font = TEST_FILE("cabin/Cabin-Regular.ttf")
     assert_PASS(check(font), "with a good font...")
-
-
-def test_check_usweightclass():
-    """Checking OS/2 usWeightClass."""
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/usweightclass")
-
-    # Our reference Mada Regular is know to be bad here.
-    font = TEST_FILE("mada/Mada-Regular.ttf")
-    ttFont = TTFont(font)
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-value", f'with bad font "{font}" ...'
-    )
-
-    # All fonts in our reference Cabin family are know to be good here.
-    for font in cabin_fonts:
-        ttFont = TTFont(font)
-        assert_PASS(check(ttFont), f'with good font "{font}"...')
-
-    # Check otf Thin == 250 and ExtraLight == 275
-    font = TEST_FILE("rokkitt/Rokkitt-Thin.otf")
-    ttFont = TTFont(font)
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-value", f'with bad font "{font}"...'
-    )
-
-    ttFont["OS/2"].usWeightClass = 250
-    assert_PASS(check(ttFont), f'with good font "{font}" (usWeightClass = 250) ...')
-
-    font = TEST_FILE("rokkitt/Rokkitt-ExtraLight.otf")
-    ttFont = TTFont(font)
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-value", f'with bad font "{font}" ...'
-    )
-
-    ttFont["OS/2"].usWeightClass = 275
-    assert_PASS(check(ttFont), f'with good font "{font}" (usWeightClass = 275) ...')
-
-    # TODO: test italic variants to ensure we do not get regressions of
-    #       this bug: https://github.com/googlefonts/fontbakery/issues/2650
-
-    # Check with VF font reported in issue:
-    # https://github.com/googlefonts/fontbakery/issues/4113
-    font = TEST_FILE("playfair/Playfair-Italic[opsz,wdth,wght].ttf")
-    ttFont = TTFont(font)
-    assert_PASS(check(ttFont), f'with good font "{font}" (usWeightClass = 300) ...')
-
-    ttFont["OS/2"].usWeightClass = 400
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-value", f'with bad font "{font}"...'
-    )
 
 
 def test_family_directory_condition():
@@ -1526,198 +1412,6 @@ def test_check_production_encoded_glyphs(cabin_ttFonts):
         assert_results_contain(check(ttFont), FAIL, "lost-glyphs")
 
 
-@pytest.mark.skip(reason="failing due to google fonts issues")
-@pytest.mark.parametrize(
-    """fp,mod,result""",
-    [
-        # tests from test_check_name_familyname:
-        (TEST_FILE("cabin/Cabin-Regular.ttf"), {}, PASS),
-        (
-            TEST_FILE("cabin/Cabin-Regular.ttf"),
-            {NameID.FONT_FAMILY_NAME: "Wrong"},
-            FAIL,
-        ),
-        (TEST_FILE("overpassmono/OverpassMono-Regular.ttf"), {}, PASS),
-        (TEST_FILE("overpassmono/OverpassMono-Bold.ttf"), {}, PASS),
-        (TEST_FILE("overpassmono/OverpassMono-Regular.ttf"), {1: "Foo"}, FAIL),
-        (TEST_FILE("merriweather/Merriweather-Black.ttf"), {}, PASS),
-        (TEST_FILE("merriweather/Merriweather-LightItalic.ttf"), {}, PASS),
-        (
-            TEST_FILE("merriweather/Merriweather-LightItalic.ttf"),
-            {NameID.FONT_FAMILY_NAME: "Merriweather Light Italic"},
-            FAIL,
-        ),
-        (TEST_FILE("abeezee/ABeeZee-Regular.ttf"), {}, PASS),
-        # tests from test_check_name_subfamilyname
-        (TEST_FILE("overpassmono/OverpassMono-Regular.ttf"), {}, PASS),
-        (TEST_FILE("overpassmono/OverpassMono-Bold.ttf"), {}, PASS),
-        (TEST_FILE("merriweather/Merriweather-Black.ttf"), {}, PASS),
-        (TEST_FILE("merriweather/Merriweather-LightItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-BlackItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Black.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Bold.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraBoldItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraBold.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraLightItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Italic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-LightItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Light.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-MediumItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Medium.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Regular.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-SemiBoldItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-SemiBold.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-ThinItalic.ttf"), {}, PASS),
-        (TEST_FILE("montserrat/Montserrat-Thin.ttf"), {}, PASS),
-        (
-            TEST_FILE("montserrat/Montserrat-ThinItalic.ttf"),
-            {NameID.FONT_SUBFAMILY_NAME: "Not a proper style"},
-            FAIL,
-        ),
-        # tests from test_check_name_fullfontname
-        (TEST_FILE("cabin/Cabin-Regular.ttf"), {}, PASS),
-        # warn should be raised since full name is missing Regular
-        (TEST_FILE("cabin/Cabin-Regular.ttf"), {4: "Cabin"}, WARN),
-        (TEST_FILE("cabin/Cabin-BoldItalic.ttf"), {}, PASS),
-        (
-            TEST_FILE("cabin/Cabin-BoldItalic.ttf"),
-            {NameID.FULL_FONT_NAME: "Make it fail"},
-            FAIL,
-        ),
-        (TEST_FILE("abeezee/ABeeZee-Regular.ttf"), {}, PASS),
-        # tests from test_check_name_typographicfamilyname
-        (TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"), {}, PASS),
-        (
-            TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"),
-            {NameID.TYPOGRAPHIC_FAMILY_NAME: "Arbitrary name"},
-            FAIL,
-        ),
-        (TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"), {}, PASS),
-        (
-            TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"),
-            {NameID.TYPOGRAPHIC_FAMILY_NAME: "Foo"},
-            FAIL,
-        ),
-        (
-            TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"),
-            {NameID.TYPOGRAPHIC_FAMILY_NAME: None},
-            FAIL,
-        ),
-        # tests from test_check_name_typographicsubfamilyname
-        (TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"), {}, PASS),
-        (
-            TEST_FILE("montserrat/Montserrat-BoldItalic.ttf"),
-            {NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Foo"},
-            FAIL,
-        ),
-        (TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"), {}, PASS),
-        (
-            TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"),
-            {NameID.TYPOGRAPHIC_SUBFAMILY_NAME: None},
-            FAIL,
-        ),
-        (
-            TEST_FILE("montserrat/Montserrat-ExtraLight.ttf"),
-            {NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Generic Name"},
-            FAIL,
-        ),
-        # variable font checks
-        (TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"), {}, PASS),
-        # Open Sans' origin is Light so this should pass
-        (
-            TEST_FILE("varfont/OpenSans[wdth,wght].ttf"),
-            {
-                NameID.FONT_SUBFAMILY_NAME: "Regular",
-                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Light",
-            },
-            PASS,
-        ),
-        (
-            TEST_FILE("varfont/OpenSans[wdth,wght].ttf"),
-            {
-                NameID.FONT_SUBFAMILY_NAME: "Regular",
-                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "Condensed Light",
-            },
-            FAIL,
-        ),
-        (TEST_FILE("varfont/RobotoSerif[GRAD,opsz,wdth,wght].ttf"), {}, FAIL),
-        # Roboto Serif has an opsz axes so this should pass
-        (
-            TEST_FILE("varfont/RobotoSerif[GRAD,opsz,wdth,wght].ttf"),
-            {
-                NameID.FONT_FAMILY_NAME: "Roboto Serif",
-                NameID.FONT_SUBFAMILY_NAME: "Regular",
-                NameID.FULL_FONT_NAME: "Roboto Serif Regular",
-                NameID.POSTSCRIPT_NAME: "RobotoSerif-Regular",
-                NameID.TYPOGRAPHIC_FAMILY_NAME: None,
-                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: None,
-            },
-            PASS,
-        ),
-        (TEST_FILE("varfont/Georama[wdth,wght].ttf"), {}, PASS),
-        # Georama's default fvar vals are wdth=62.5, wght=100
-        # which means ExtraCondensed Thin should appear in the family name
-        (
-            TEST_FILE("varfont/Georama[wdth,wght].ttf"),
-            {
-                NameID.FONT_FAMILY_NAME: "Georama ExtraCondensed Thin",
-                NameID.FONT_SUBFAMILY_NAME: "Regular",
-                NameID.TYPOGRAPHIC_FAMILY_NAME: "Georama",
-                NameID.TYPOGRAPHIC_SUBFAMILY_NAME: "ExtraCondensed Thin",
-            },
-            PASS,
-        ),
-    ],
-)
-def test_check_font_names(fp, mod, result):
-    """Check font names are correct"""
-    # Please note: This check was introduced in
-    # https://github.com/googlefonts/fontbakery/pull/3800 which has replaced
-    # the following checks:
-    #   com.google.fonts/check/name/familyname
-    #   com.google.fonts/check/name/subfamilyname
-    #   com.google.fonts/check/name/typographicfamilyname
-    #   com.google.fonts/check/name/typographicsubfamilyname
-    # It works by simply using the nametable builder which is found in the
-    # axis registry,
-    # https://github.com/googlefonts/axisregistry/blob/main/Lib/axisregistry/__init__.py#L232
-    # this repository already has good unit tests but this check will also include the
-    # previous test cases found in openbakery.
-    # https://github.com/googlefonts/axisregistry/blob/main/tests/test_names.py
-
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/font_names")
-    ttFont = TTFont(fp)
-    # get the expecteed font names now before we modify them
-    expected = expected_font_names(ttFont, [])
-    if mod:
-        for k, v in mod.items():
-            if v is None:
-                ttFont["name"].removeNames(k)
-            else:
-                ttFont["name"].setName(v, k, 3, 1, 0x409)
-
-    if result == PASS:
-        assert_PASS(
-            check(ttFont, {"expected_font_names": expected}), "with a good font..."
-        )
-    elif result == WARN:
-        assert_results_contain(
-            check(ttFont, {"expected_font_names": expected}),
-            WARN,
-            "lacks-regular",
-            "with bad names",
-        )
-    else:
-        assert_results_contain(
-            check(ttFont, {"expected_font_names": expected}),
-            FAIL,
-            "bad-names",
-            "with bad names",
-        )
-
-
 def test_check_name_mandatory_entries():
     """Font has all mandatory 'name' table entries ?"""
     check = CheckTester(
@@ -2052,72 +1746,6 @@ def test_check_aat():
             "has-unwanted-tables",
             f"with unwanted table {unwanted} ...",
         )
-
-
-def test_check_fvar_name_entries():
-    """All name entries referenced by fvar instances exist on the name table?"""
-    # TODO fix
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-
-    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
-
-    # rename the first fvar instance so the font is broken
-    ttFont["name"].setName("foo", 258, 3, 1, 0x409)
-
-    # So it must FAIL the check:
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-fvar-instances", "with a bad font..."
-    )
-
-    # rename the first fvar instance so it is correct
-    ttFont["name"].setName("Regular", 258, 3, 1, 0x409)
-
-    assert_PASS(check(ttFont), "with a good font...")
-
-
-def test_check_varfont_has_instances():
-    """A variable font must have named instances."""
-    # TODO Fix!
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-
-    # ExpletusVF does have instances.
-    # Note: The "broken" in the path name refers to something else.
-    #       (See test_check_fvar_name_entries)
-    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
-
-    # So it must PASS the check:
-    assert_PASS(check(ttFont), "with a good font...")
-
-    # If we delete all instances, then it must FAIL:
-    while len(ttFont["fvar"].instances):
-        del ttFont["fvar"].instances[0]
-
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-fvar-instances", "with a bad font..."
-    )
-
-
-def test_check_varfont_weight_instances():
-    """Variable font weight coordinates must be multiples of 100."""
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-
-    # This copy of Markazi Text has an instance with
-    # a 491 'wght' coordinate instead of 500.
-    ttFont = TTFont(TEST_FILE("broken_markazitext/MarkaziText-VF.ttf"))
-
-    # So it must FAIL the check:
-    assert_results_contain(
-        check(ttFont), FAIL, "bad-fvar-instances", "with a bad font..."
-    )
-
-    # Let's then change the weight coordinates to make it PASS the check:
-    # instances are from 400-700 (Regular-Bold) so set start to 400
-    wght_val = 400
-    for i, instance in enumerate(ttFont["fvar"].instances):
-        ttFont["fvar"].instances[i].coordinates["wght"] = wght_val
-        wght_val += 100
-
-    assert_PASS(check(ttFont), "with a good font...")
 
 
 def NOT_IMPLEMENTED_test_check_family_tnum_horizontal_metrics():
@@ -2940,63 +2568,6 @@ def test_check_cjk_not_enough_glyphs():
     assert msg.startswith("There are only 2 CJK glyphs")
 
 
-def test_check_varfont_instance_coordinates(vf_ttFont):
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-
-    # OpenSans-Roman-VF is correct
-    assert_PASS(
-        check(vf_ttFont), "with a variable font which has correct instance coordinates."
-    )
-
-    from copy import copy
-
-    vf_ttFont2 = copy(vf_ttFont)
-    for instance in vf_ttFont2["fvar"].instances:
-        for axis in instance.coordinates.keys():
-            instance.coordinates[axis] = 0
-    assert_results_contain(
-        check(vf_ttFont2),
-        FAIL,
-        "bad-fvar-instances",
-        "with a variable font which does not have correct instance coordinates.",
-    )
-
-
-def test_check_varfont_instance_names(vf_ttFont):
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-
-    assert_PASS(
-        check(vf_ttFont), "with a variable font which has correct instance names."
-    )
-
-    from copy import copy
-
-    vf_ttFont2 = copy(vf_ttFont)
-    for instance in vf_ttFont2["fvar"].instances:
-        instance.subfamilyNameID = 300
-    broken_name = "ExtraBlack Condensed 300pt"
-    vf_ttFont2["name"].setName(
-        broken_name,
-        300,
-        PlatformID.MACINTOSH,
-        MacintoshEncodingID.ROMAN,
-        MacintoshLanguageID.ENGLISH,
-    )
-    vf_ttFont2["name"].setName(
-        broken_name,
-        300,
-        PlatformID.WINDOWS,
-        WindowsEncodingID.UNICODE_BMP,
-        WindowsLanguageID.ENGLISH_USA,
-    )
-    assert_results_contain(
-        check(vf_ttFont2),
-        FAIL,
-        "bad-fvar-instances",
-        "with a variable font which does not have correct instance names.",
-    )
-
-
 def test_check_varfont_duplicate_instance_names(vf_ttFont):
     check = CheckTester(
         googlefonts_profile, "com.google.fonts/check/varfont_duplicate_instance_names"
@@ -3079,57 +2650,6 @@ def test_check_varfont_grade_reflow():
 
     ttFont["GPOS"].table.LookupList.Lookup = []
     assert_PASS(check(ttFont))
-
-
-def test_check_gf_axisregistry_fvar_axis_defaults():
-    """Validate fvar axis defaults match registered fallback names in GFAxisRegistry."""
-    check = CheckTester(
-        googlefonts_profile, "com.google.fonts/check/gf_axisregistry/fvar_axis_defaults"
-    )
-
-    # The default value for the axes in this reference varfont
-    # are properly registered in the registry:
-    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
-    assert_PASS(check(ttFont))
-
-    # And this value surely doen't map to a fallback name in the registry
-    ttFont["fvar"].axes[0].defaultValue = 123
-    assert_results_contain(check(ttFont), FAIL, "not-registered")
-
-
-def test_check_STAT_gf_axisregistry():
-    """
-    Validate STAT particle names and values match the fallback names in GFAxisRegistry.
-    """
-    check = CheckTester(
-        googlefonts_profile, "com.google.fonts/check/STAT/gf_axisregistry"
-    )
-
-    # Our reference varfont, CabinVF,
-    # has "Regular", instead of "Roman" in its 'ital' axis on the STAT table:
-    ttFont = TTFont(TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"))
-    assert_results_contain(check(ttFont), FAIL, "invalid-name")
-
-    # LibreCaslonText is good though:
-    ttFont = TTFont(TEST_FILE("librecaslontext/LibreCaslonText[wght].ttf"))
-    assert_PASS(check(ttFont))
-
-    # Let's break it by setting an invalid coordinate for "Bold":
-    assert (
-        ttFont["STAT"].table.AxisValueArray.AxisValue[3].ValueNameID
-        == ttFont["name"].names[4].nameID
-    )
-    assert ttFont["name"].names[4].toUnicode() == "Bold"
-    # instead of the expected 700
-    # Note: I know it is AxisValue[3] and names[4]
-    # because I inspected the font using ttx.
-    ttFont["STAT"].table.AxisValueArray.AxisValue[3].Value = 800
-    assert_results_contain(check(ttFont), FAIL, "bad-coordinate")
-
-    # Let's remove all Axis Values. This will fail since we Google Fonts
-    # requires them.
-    ttFont["STAT"].table.AxisValueArray = None
-    assert_results_contain(check(ttFont), FAIL, "missing-axis-values")
 
 
 def test_check_STAT_axis_order():
@@ -3336,133 +2856,6 @@ def test_check_description_urls():
 
     good_desc = check["description"].replace(">https://", ">")
     assert_PASS(check(font, {"description": good_desc}))
-
-
-@pytest.mark.parametrize(
-    """fp,mod,result""",
-    [
-        # font includes condensed fvar instances so it should fail
-        (TEST_FILE("cabinvfbeta/CabinVFBeta.ttf"), [], FAIL),
-        # official fonts have been fixed so this should pass
-        (TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"), [], PASS),
-        (TEST_FILE("cabinvf/Cabin-Italic[wdth,wght].ttf"), [], PASS),
-        # lets inject an instance which is not a multiple of 100
-        (TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"), [("Book", 450)], FAIL),
-    ],
-)
-def test_check_fvar_instances(fp, mod, result):
-    """Check font fvar instances are correct"""
-    from fontTools.ttLib.tables._f_v_a_r import NamedInstance
-
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/fvar_instances")
-    ttFont = TTFont(fp)
-    expected = expected_font_names(ttFont, [])
-    if mod:
-        for name, wght_val in mod:
-            inst = NamedInstance()
-            inst.subfamilyNameID = ttFont["name"].addName(name)
-            inst.coordinates = {"wght": wght_val}
-            ttFont["fvar"].instances.append(inst)
-
-    if result == PASS:
-        assert_PASS(
-            check(ttFont, {"expected_font_names": expected}), "with a good font"
-        )
-    elif result == FAIL:
-        assert_results_contain(
-            check(ttFont, {"expected_font_names": expected}),
-            FAIL,
-            "bad-fvar-instances",
-            "with a bad font",
-        )
-
-
-@pytest.mark.parametrize(
-    """fps,new_stat,result""",
-    [
-        # Fail (we didn't really know what we were doing at this stage)
-        (
-            [
-                TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"),
-                TEST_FILE("cabinvf/Cabin-Italic[wdth,wght].ttf"),
-            ],
-            [],
-            FAIL,
-        ),
-        # Fix previous test for Cabin[wdth,wght].ttf
-        (
-            [
-                TEST_FILE("cabinvf/Cabin[wdth,wght].ttf"),
-                TEST_FILE("cabinvf/Cabin-Italic[wdth,wght].ttf"),
-            ],
-            # STAT for Cabin[wdth,wght].ttf
-            [
-                {
-                    "name": "Weight",
-                    "tag": "wght",
-                    "values": [
-                        {
-                            "value": 400,
-                            "name": "Regular",
-                            "linkedValue": 700.0,
-                            "flags": 0x2,
-                        },
-                        {"value": 500, "name": "Medium"},
-                        {"value": 600, "name": "SemiBold"},
-                        {"value": 700, "name": "Bold"},
-                    ],
-                },
-                {
-                    "name": "Width",
-                    "tag": "wdth",
-                    "values": [
-                        {"value": 75, "name": "Condensed"},
-                        {"value": 87.5, "name": "SemiCondensed"},
-                        {"value": 100, "name": "Normal", "flags": 0x2},
-                    ],
-                },
-                {
-                    "name": "Italic",
-                    "tag": "ital",
-                    "values": [
-                        {
-                            "value": 0.0,
-                            "name": "Normal",
-                            "linkedValue": 1.0,
-                            "flags": 0x2,
-                        }
-                    ],
-                },
-            ],
-            PASS,
-        ),
-    ],
-)
-def test_check_STAT(fps, new_stat, result):
-    """Check STAT table Axis Values are correct"""
-    # more comprehensive checks are available in the axisregistry:
-    # https://github.com/googlefonts/axisregistry/blob/main/tests/test_names.py#L442
-    # this check merely exists to check that everything is hooked up correctly
-    from fontTools.otlLib.builder import buildStatTable
-
-    check = CheckTester(googlefonts_profile, "com.google.fonts/check/STAT")
-    ttFonts = [TTFont(f) for f in fps]
-    ttFont = ttFonts[0]
-    expected = expected_font_names(ttFont, ttFonts)
-    if new_stat:
-        buildStatTable(ttFont, new_stat)
-
-    if result == PASS:
-        assert_PASS(
-            check(ttFont, {"expected_font_names": expected}), "with a good font"
-        )
-    elif result == FAIL:
-        assert_results_contain(
-            check(ttFont, {"expected_font_names": expected}),
-            FAIL,
-            "bad-axis-values",
-            "with a bad font",
-        )
 
 
 def test_check_colorfont_tables():


### PR DESCRIPTION
Drop the axisregistry package entirely from requirements.txt and setup.py. Delete the 7 googlefonts-profile checks that relied on it (canonical_filename, usweightclass, font_names, STAT, fvar_instances, gf_axisregistry/fvar_axis_defaults, STAT/gf_axisregistry), the two backing conditions (GFAxisRegistry, expected_font_names), their tests, and the CI workflow invocations that referenced them. Also clean up five stale tests in googlefonts_test.py that pointed at the removed fvar_instances check (some already carried "TODO fix" comments), drop fontwerk's exclusion entry for canonical_filename, and swap the canonical_filename reference in tests/commands/test_usage.py for an existing check ID so the CLI smoke test still runs.

adobefonts is unaffected (it allowlists checks explicitly and never listed any of these). Verified: pyflakes clean (modulo pre-existing warnings), all four profile modules import, full pytest passes (419 passed, 10 skipped, 2 xfailed), and end-to-end CLI runs of all four profiles succeed.

## Checklist
- [ ] update `CHANGELOG.md`
- [ ] wait for the tests to pass
- [ ] request a review

